### PR TITLE
added PR template, guidelines, and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+*       @NebraLtd/developers
+
+# See example for more details: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -1,0 +1,35 @@
+# How to contriubte
+
+Thanks for your interest in contributing to Nebra. We enforce certain rules on commits with the following goals in mind:
+
+- Be able to reliably auto-generate the `CHANGELOG.md` *without* any human intervention.
+- Be able to automatically and correctly increment the semver version number based on what was done since the last release.
+- Be able to get a quick overview of what happened to the project by glancing over the commit history.
+- Be able to automatically reference relevant changes from a dependency upgrade.
+
+Our CI will run checks to ensure this guidelines are followed and won't allow merging contributions that don't adhere to them. Version number and changelog are automatically handled by the CI build flow after a pull request is merged. You only need to worry about the commit itself.
+
+## Commit structure
+
+Each commit message should consist of a header a body and a footer, structured in the following format:
+
+```
+<scope (optional)>: <subject (mandatory)>
+--BLANK LINE--
+(optional) <body>
+--BLANK LINE--
+(optional) Connects-to: #issue-number
+(optional) Closes: #issue-number
+(mandatory) Change-type: major | minor | patch
+(optional) Signed-off-by: Foo Bar <foobar@balena.io>
+```
+
+Note that:
+- Blank lines are required to separate header from body and body from footer. You don't need to add two blank lines if you don't add a body.
+- `scope`: If your commit touches a well defined component/part/service please addthe scope tag to clarify. Some examples: `docs`, `images`, `typos`.
+- `subject`: The subject should contain a short description of the change. Use the imperative, present tense.
+- `body`: A detailed description of changes being made and reasoning if necessary. This may contain several paragraphs.
+- `Connects-to`: If your commit is connected to an existing issue, link it by adding this tag with `#issue-number`. Example: `Connects-to: #123`
+- `Closes`: If your commit fixes an existing issue, link it by adding this tag with `#issue-number`. Example: `Closes: #123`
+- `Change-type`: At least one of your commits on a PR needs to have this tag. You have the flexibility, and it's good practise, to use this tag in as many commits as you see fit; in the end, the resulting change type for the scope of the PR will be folded down to the biggest one as marked in the commits (`major>minor>patch`). Our version numbering adheres to [Semantic Versioning](http://semver.org/).
+- `Signed-off-by`: Sign your commits by providing your full name and email address in the format: `Name Surname <email@something.com>`. *This is an optional tag.*

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+**Why**
+<!-- What is the objective of this work? -->
+
+**How**
+<!-- What steps were taken in this work? -->
+<!-- Its encouraged to copy information from other places even if it seems redundant -->
+
+**References**
+<!-- Links to related issues, relevant documentation, etc. -->

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -34,5 +34,5 @@ jobs:
     - name: Unit tests
       working-directory: ./diagnostics-program
       run: |
-        wget "https://raw.githubusercontent.com/NebraLtd/helium-hardware-definitions/master/variant_definitions.py"
+        wget "https://raw.githubusercontent.com/NebraLtd/helium-hardware-definitions/master/src/hm_hardware_defs/variant.py"
         python3 -m unittest

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,6 @@ COPY diagnostics-program /opt/
 COPY default.conf /etc/nginx/conf.d/default.conf
 COPY bootstrap.min.css /opt/html/bootstrap.min.css
 
-RUN wget "https://raw.githubusercontent.com/NebraLtd/helium-hardware-definitions/master/variant_definitions.py"
+RUN wget "https://raw.githubusercontent.com/NebraLtd/helium-hardware-definitions/master/src/hm_hardware_defs/variant.py"
 
 ENTRYPOINT ["sh", "/opt/start_diagnostics.sh"]


### PR DESCRIPTION
**Why**
A developer should be presented with a template when opening a PR so that they are prompted to give more detailed information and a set of developers should automatically be assigned to review.

**How**
Added `pull_request_template.md` and `contributing.md` to `.github/`.
The Google Doc referenced in `contributing.md` is currently empty.
Added all developers to CODEOWNERS.

**References**
- [PR template instructions](https://docs.github.com/en/communities/setting-up-your-project-for-healthy-contributions/setting-guidelines-for-repository-contributors)
- [CODEOWNERS instructions](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file)