### PR TITLE
Format sync percentage as per Issue #104

### DIFF
--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -44,7 +44,11 @@
                 </tr>
                 <tr>
                   <td>Sync Percentage</td>
-                  <td class="text-right">{{ diagnostics.BSP }}%</td>
+                  {% if diagnostics.BSP > 99.98 %}
+                    <td class="text-right">100%</td>
+                  {% else %}
+                    <td class="text-right">{{ '%0.2f' % diagnostics.BSP|float }}%</td>
+                  {% endif %}
                 </tr>
                 <tr>
                   <td>Height Status</td>


### PR DESCRIPTION
Format sync percentage as described in #104 

- If greater than 99.8% consider the miner as synced and display 100%
- Format float as 2 decimal places
- Display 100% for percentages > 100%

Closes: #104 