### PR TITLE
mdns: change hostname to something useful

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
     labels:
       io.balena.features.sysfs: '1'
       io.balena.features.dbus: '1'
+      io.balena.features.supervisor-api: '1'
 
 volumes:
   miner-storage:

--- a/hw_diag/app.py
+++ b/hw_diag/app.py
@@ -5,6 +5,7 @@ from flask import Flask
 from flask_apscheduler import APScheduler
 
 from hw_diag.tasks import perform_hw_diagnostics
+from hw_diag.utilities.hostname import set_hostname
 from hw_diag.views.diagnostics import DIAGNOSTICS
 
 
@@ -32,6 +33,10 @@ def get_app(name):
     @scheduler.task('cron', id='run_diagnostics', minute='*/1')
     def run_diagnostics_task():
         perform_hw_diagnostics()
+
+    # Set hostname for mdns / netbios
+    def run_hostname_task():
+        set_hostname()
 
     # Register Blueprints
     app.register_blueprint(DIAGNOSTICS)

--- a/hw_diag/utilities/hostname.py
+++ b/hw_diag/utilities/hostname.py
@@ -1,0 +1,26 @@
+import os
+import requests
+
+from hw_diag.utilities.hardware import get_mac_addr
+
+def set_hostname():
+    """
+    Sets the hostname of the miner to nebra-<last 6 of mac>
+    via the balena supervisor api
+    """
+    path = "/sys/class/net/eth0/address"
+    eth0 = get_mac_addr(path).replace(':','').lower()
+    length = len(eth0)
+    supervisor_addr = os.environ.get('BALENA_SUPERVISOR_ADDRESS')
+    api_key = os.environ.get('BALENA_SUPERVISOR_API_KEY')
+
+    headers = {
+        'Content-Type': 'application/json',
+    }
+    params = (
+        ('apikey', api_key),
+    )
+    data = '{{"network": {{"hostname": "nebra-{}"}}}}'.format(eth0[length - 6:])
+    response = requests.patch(supervisor_addr + '/v1/device/host-config', headers=headers, params=params, data=data)
+
+    return response

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,10 @@ setup(
     name=base_name,
     version='1.0',
     author=u'Nebra Ltd.',
-    author_email='nebra.com',
+    author_email='sales@nebra.com',
     include_package_data = True,
     packages=find_packages(), # include all packages under this directory
-    description='to update',
+    description='Diagnostics tool for Nebra Helium Hotspot software.',
     long_description="",
     zip_safe=False,
 


### PR DESCRIPTION
changes hostname to nebra-<last 6 chars of mac>.local instead of balena uuid

Relates-to: #41
Signed-off-by: Aaron Shaw <shawaj@gmail.com>

**Why**
<!-- What is the objective of this work? -->

Make the diagnostics page easier to find locally, without knowing the local IP address of the unit.

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Add a new function to set the hostname using the balena supervisor API

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Part of #41 