### PR TITLE
json: make json downloadable instead of in browser

### DIFF
--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -28,7 +28,9 @@ def get_diagnostics():
     diagnostics = read_diagnostics_file()
 
     if request.args.get('json'):
-        return jsonify(diagnostics)
+        response = jsonify(diagnostics)
+        response.headers.set('Content-Disposition', 'attachment;filename=nebra-diag.json')
+        return response
 
     display_lte = should_display_lte(diagnostics)
 


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

make json output a downloadable file

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Add request headers using
`response.headers.set('Content-Disposition', 'attachment;filename=nebra-diag.json')`

**References**
<!-- Links to related issues, relevant documentation, etc. -->