### PR TITLE
Deprecate hm-upnp rep

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apk add --no-cache \
     python3=3.8.10-r0 \
     i2c-tools=4.1-r3 \
     usbutils=012-r1 \
+    miniupnpc=2.1.20191224-r0 \
     py3-pip=20.1.1-r0 \
     py3-certifi=2020.4.5.1-r0 \
     py3-urllib3=1.25.9-r0 \
@@ -18,7 +19,7 @@ RUN apk add --no-cache \
 RUN mkdir /tmp/build
 COPY ./ /tmp/build
 WORKDIR /tmp/build
-RUN pip install -r /tmp/build/requirements.txt 
+RUN pip install -r /tmp/build/requirements.txt
 RUN python3 setup.py install
 RUN rm -rf /tmp/build
 

--- a/hw_diag/app.py
+++ b/hw_diag/app.py
@@ -4,7 +4,7 @@ import os
 from flask import Flask
 from flask_apscheduler import APScheduler
 
-from hw_diag.tasks import perform_hw_diagnostics
+from hw_diag.tasks import perform_hw_diagnostics, attempt_to_set_up_upnp
 from hw_diag.views.diagnostics import DIAGNOSTICS
 
 
@@ -32,6 +32,10 @@ def get_app(name):
     @scheduler.task('cron', id='run_diagnostics', minute='*/1')
     def run_diagnostics_task():
         perform_hw_diagnostics()
+
+    @scheduler.task('cron', id='run_upnp_setup', minute='00')
+    def run_upnp_setup_task():
+        attempt_to_set_up_upnp()
 
     # Register Blueprints
     app.register_blueprint(DIAGNOSTICS)

--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -1,6 +1,7 @@
 import logging
 import datetime
 import json
+import subprocess
 
 from hw_diag.utilities.blockchain import get_helium_blockchain_height
 from hw_diag.utilities.hardware import get_ethernet_addresses
@@ -107,3 +108,13 @@ def perform_hw_diagnostics():
         json.dump(diagnostics, f)
 
     log.info('Diagnostics complete')
+
+
+def attempt_to_set_up_upnp():
+    """
+    Brute force uPNP configuration.
+
+    @TODO: Rewrite this with a check if uPNP is available and check for status.
+    """
+
+    subprocess.run(["/usr/bin/upnpc", "-e", "Nebra Helium", "-r", "44158", "TCP"])  # nosec (B603)


### PR DESCRIPTION
**Why**

Because we want to reduce the footprint. Closes #123.

**How**

Ports https://github.com/NebraLtd/hm-upnp almost line-by-line but with the help of new cron task executer

This should probably be rewritten later with something like [uPnPy](https://pypi.org/project/UPnPy/).

Will require changes to the main docker-compose file.

**References**

* https://github.com/NebraLtd/hm-diag/issues/123
* https://github.com/NebraLtd/hm-upnp