### PR TITLE
Deprecates hardware-definition python module

### DIFF
--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -2,15 +2,15 @@ import logging
 import datetime
 import json
 
+from hm_pyhelper.hardware_definitions import variant_definitions
 from hm_pyhelper.miner_param import get_ethernet_addresses
 from hw_diag.utilities.blockchain import get_helium_blockchain_height
-from hw_diag.utilities.hardware import get_rpi_serial
 from hw_diag.utilities.hardware import detect_ecc
-from hw_diag.utilities.hardware import set_diagnostics_bt_lte
+from hw_diag.utilities.hardware import get_rpi_serial
 from hw_diag.utilities.hardware import lora_module_test
+from hw_diag.utilities.hardware import set_diagnostics_bt_lte
 from hw_diag.utilities.miner import fetch_miner_data
 from hw_diag.utilities.shell import get_environment_var
-from hm_hardware_defs.variant import variant_definitions
 
 
 log = logging.getLogger()

--- a/hw_diag/tests/test_get_miner_diag.py
+++ b/hw_diag/tests/test_get_miner_diag.py
@@ -22,6 +22,7 @@ PEER_BOOK = [
     }
 ]
 
+
 class TestGetMinerDiag(unittest.TestCase):
 
     @patch('hw_diag.utilities.miner.client')

--- a/hw_diag/utilities/hardware.py
+++ b/hw_diag/utilities/hardware.py
@@ -2,7 +2,7 @@ import logging
 import os
 from time import sleep
 
-from hm_hardware_defs.variant import variant_definitions
+from hm_pyhelper.hardware_definitions import variant_definitions
 from hw_diag.utilities.shell import config_search_param
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,5 @@ certifi==2021.5.30
 dbus-python==1.2.16
 gunicorn==20.1.0
 requests==2.26.0
-hm-hardware-defs==0.1.6a3
 hm-pyhelper==0.4
 sentry-sdk==1.1.0


### PR DESCRIPTION
* Deprecates [helium-hardware-definitions](https://github.com/NebraLtd/helium-hardware-definitions) in favor of [hm-pyhelper](https://github.com/NebraLtd/hm-pyhelper)
* Fixes linting error
* Sort imports