### PR TITLE
feat: do not exec diagnostics if gwmfr running

### DIFF
--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -29,7 +29,7 @@ def perform_hw_diagnostics(ship=False):
     log.info('Running periodic hardware diagnostics')
 
     if is_gwmfr_running():
-        log.info("hm-gwmfr is still runnning. Diagnostics will not be executed.")
+        log.info("gwmfr running. Diags will not be executed.")
         return
 
     diagnostics = {}

--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -25,8 +25,7 @@ def is_gwmfr_running():
     return not os.path.isfile(ECC_SUCCESSFUL_TOUCH_FILEPATH)
 
 
-# noqa: C901
-def perform_hw_diagnostics(ship=False):
+def perform_hw_diagnostics(ship=False):  # noqa: C901
     log.info('Running periodic hardware diagnostics')
 
     if is_gwmfr_running():

--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -25,6 +25,7 @@ def is_gwmfr_running():
     return not os.path.isfile(ECC_SUCCESSFUL_TOUCH_FILEPATH)
 
 
+# noqa: C901
 def perform_hw_diagnostics(ship=False):
     log.info('Running periodic hardware diagnostics')
 

--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -1,6 +1,8 @@
 import logging
 import datetime
 import json
+import os.path
+
 from hm_pyhelper.hardware_definitions import variant_definitions
 from hm_pyhelper.miner_param import get_ethernet_addresses
 from hw_diag.utilities.blockchain import get_helium_blockchain_height
@@ -16,11 +18,12 @@ from hw_diag.utilities.gcs_shipper import upload_diagnostics
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
-import os.path
 ECC_SUCCESSFUL_TOUCH_FILEPATH = "/var/data/gwmfr_ecc_provisioned"
+
 
 def is_gwmfr_running():
     return not os.path.isfile(ECC_SUCCESSFUL_TOUCH_FILEPATH)
+
 
 def perform_hw_diagnostics(ship=False):
     log.info('Running periodic hardware diagnostics')

--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -1,7 +1,6 @@
 import logging
 import datetime
 import json
-
 from hm_pyhelper.hardware_definitions import variant_definitions
 from hm_pyhelper.miner_param import get_ethernet_addresses
 from hw_diag.utilities.blockchain import get_helium_blockchain_height
@@ -17,9 +16,18 @@ from hw_diag.utilities.gcs_shipper import upload_diagnostics
 log = logging.getLogger()
 log.setLevel(logging.DEBUG)
 
+import os.path
+ECC_SUCCESSFUL_TOUCH_FILEPATH = "/var/data/gwmfr_ecc_provisioned"
+
+def is_gwmfr_running():
+    return not os.path.isfile(ECC_SUCCESSFUL_TOUCH_FILEPATH)
 
 def perform_hw_diagnostics(ship=False):
     log.info('Running periodic hardware diagnostics')
+
+    if is_gwmfr_running():
+        log.info("hm-gwmfr is still runnning. Diagnostics will not be executed.")
+        return
 
     diagnostics = {}
 

--- a/hw_diag/utilities/miner.py
+++ b/hw_diag/utilities/miner.py
@@ -1,7 +1,3 @@
-import json
-import logging
-import subprocess
-
 from hm_pyhelper.miner_json_rpc import MinerClient
 
 

--- a/hw_diag/utilities/miner.py
+++ b/hw_diag/utilities/miner.py
@@ -7,6 +7,7 @@ from hm_pyhelper.miner_json_rpc import MinerClient
 
 client = MinerClient()
 
+
 def fetch_miner_data(diagnostics):
     # Fetch miner keys from miner container and append
     # them to the diagnostics dictionary.

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -1,6 +1,6 @@
 import json
 import base64
-import os.path
+import os
 import logging
 
 from flask import Blueprint

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -53,8 +53,10 @@ def get_diagnostics():
         display_lte=display_lte
     )
 
+
 def is_gwmfr_running():
     return not os.path.isfile(ECC_SUCCESSFUL_TOUCH_FILEPATH)
+
 
 @DIAGNOSTICS.route('/initFile.txt')
 def get_initialisation_file():
@@ -62,9 +64,10 @@ def get_initialisation_file():
     This needs to be generated as quickly as possible,
     so we bypass the regular timer.
     """
-    
+
     if is_gwmfr_running():
-        logging.info("hm-gwmfr is still runnning. initFile.txt will not be returned")
+        logging.info("hm-gwmfr is still runnning. \
+            initFile.txt will not be returned.")
         return 'hm-gwmfr is still running. ECC cannot be accessed yet.', 500
 
     diagnostics = {}

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -66,8 +66,7 @@ def get_initialisation_file():
     """
 
     if is_gwmfr_running():
-        logging.info("hm-gwmfr is still runnning. \
-            initFile.txt will not be returned.")
+        logging.info("gwmfr runnning. initFile will not be returned.")
         return 'hm-gwmfr is still running. ECC cannot be accessed yet.', 500
 
     diagnostics = {}

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -67,7 +67,7 @@ def get_initialisation_file():
 
     if is_gwmfr_running():
         logging.info("gwmfr runnning. initFile will not be returned.")
-        return 'hm-gwmfr is still running. ECC cannot be accessed yet.', 500
+        return 'hm-gwmfr is still running. ECC cannot be accessed yet.', 503
 
     diagnostics = {}
     get_rpi_serial(diagnostics)

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -79,12 +79,12 @@ def get_initialisation_file():
     if ecc_tests['result'] == 'pass':
         diagnostics["ECC"] = True
     else:
-        return 'ECC tests failed', 500
+        return 'ECC tests failed', 503
 
     if lora_module_test():
         diagnostics["LOR"] = True
     else:
-        return 'LoRa Module is not ready', 500
+        return 'LoRa Module is not ready', 503
 
     if (
             diagnostics["ECC"] is True


### PR DESCRIPTION
**Why**
Some ECC chips are being corrupted during manufacturing. There may be a race condition between gwmfr and diag. We want to wait for gwmfr to complete before running diagnostics.

**How**
Write to an empty file (AKA touch) when gwmfr completes successfully. Wait for this file to be present before running diagnostics.

**References**
- Slack convo: https://pisupply.slack.com/archives/C024BNQ1Y6T/p1632912403459500
- gwmfr: https://github.com/NebraLtd/hm-gwmfr/pull/18
- helium-miner-software: https://github.com/NebraLtd/helium-miner-software/pull/155