### PR TITLE
remove dbus

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,6 @@ RUN apk add --no-cache \
     build-base \
     python3-dev \
     glib-dev \
-    dbus-dev \
     py3-pip=20.1.1-r0
 
 RUN mkdir /tmp/build

--- a/README.md
+++ b/README.md
@@ -86,3 +86,11 @@ This is no longer [the recommended way](https://www.balena.io/docs/learn/deploy/
 ## Access from other networks
 
 Balena will generate a public URL for a device if [PUBLIC DEVICE URL](https://www.balena.io/docs/learn/manage/actions/#enable-public-device-url) is toggled from the Balena device dashboard. This is not generally recommended, except for debugging.
+
+## Pre built containers
+
+This repo automatically builds docker containers and uploads them to two repositories for easy access:
+- [hm-diag on DockerHub](https://hub.docker.com/r/nebraltd/hm-diag)
+- [hm-diag on GitHub Packages](https://github.com/NebraLtd/hm-diag/pkgs/container/hm-diag)
+
+The images are tagged using the docker long and short commit SHAs for that release. The current version deployed to miners can be found in the [helium-miner-software repo](https://github.com/NebraLtd/helium-miner-software/blob/production/docker-compose.yml).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,6 @@ services:
     build: .
     environment:
       - 'FIRMWARE_VERSION=2021.08.02.0'
-      - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     volumes:
       - 'pktfwdr:/var/pktfwd'
       - 'miner-storage:/var/data'
@@ -18,7 +17,6 @@ services:
       - "/dev/i2c-1:/dev/i2c-1"
     labels:
       io.balena.features.sysfs: '1'
-      io.balena.features.dbus: '1'
 
 volumes:
   miner-storage:

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ Flask-APScheduler==1.12.2
 Flask==2.0.1
 certifi==2021.5.30
 click==7.1.2
-dbus-python==1.2.16
 gunicorn==20.1.0
 hm-pyhelper==0.7
 requests==2.26.0

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ setup(
     install_requires=['Flask==2.0.1',
                       'Flask-APScheduler==1.12.2',
                       'requests==2.26.0',
-                      'dbus-python==1.2.16',
                       'hm-pyhelper==0.4',
                       'click==7.1.2'
                       ]


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

dbus is no longer used as we are getting the miner data through json rpc after #113 and #153 

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

remove all dbus references from container

**References**
<!-- Links to related issues, relevant documentation, etc. -->

#113 
#153 
#149 