### PR TITLE
Run diagnostics more frequently

### DIFF
--- a/hw_diag/app.py
+++ b/hw_diag/app.py
@@ -40,7 +40,7 @@ def get_app(name):
     @scheduler.task(
         'cron',
         id='run_diagnostics',
-        minute='1,2,3,4,5,10,15,20,25,30,35,40,45,50,55')
+        minute='*')
     def run_diagnostics_task():
         perform_hw_diagnostics(ship=False)
 


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

Current functionality runs every 5 minutes between the 5th and 55th minutes of the hour. This means it can take up to 5 to run at first boot and at the turn of the hour will not run from x.55 until x+1.05 (10 minute gap)

Seems better to run this every minute instead

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Change schedule

**References**
<!-- Links to related issues, relevant documentation, etc. -->

https://apscheduler.readthedocs.io/en/3.x/modules/triggers/cron.html