### PR TITLE
feat: use same base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ HEALTHCHECK \
   CMD wget -q -O - http://0.0.0.0:5000/initFile.txt || exit 1
 
 RUN \
-    install_packages
+    install_packages \
       i2c-tools \
       usbutils
 


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

Using same base image across all containers will reduce number of layers and therefore reduce image size of OS image

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Change base image across as many containers as possible to reduce image size

**References**
<!-- Links to related issues, relevant documentation, etc. -->

https://github.com/NebraLtd/helium-miner-software/issues/182