### PR TITLE
feat: no concurrent ecc usage

### DIFF
--- a/hw_diag/diagnostics/ecc_diagnostic.py
+++ b/hw_diag/diagnostics/ecc_diagnostic.py
@@ -1,7 +1,6 @@
 import json
 from hm_pyhelper.miner_param import get_gateway_mfr_test_result
 from hm_pyhelper.diagnostics.diagnostic import Diagnostic
-from hm_pyhelper.exceptions import ECCMalfunctionException
 
 KEY = 'ECC'
 FRIENDLY_NAME = "ECC"
@@ -22,5 +21,5 @@ class EccDiagnostic(Diagnostic):
                       str(json.dumps(ecc_tests))
                 diagnostics_report.record_failure(msg, self)
 
-        except ECCMalfunctionException as e:
+        except Exception as e:
             diagnostics_report.record_failure(str(e), self)

--- a/hw_diag/diagnostics/key_diagnostics.py
+++ b/hw_diag/diagnostics/key_diagnostics.py
@@ -22,10 +22,15 @@ class KeyDiagnostic(Diagnostic):
         self.key_path = key_path
 
     def perform_test(self, diagnostics_report):
-        public_keys = get_public_keys_rust()
+        # Try to get key, but there may be ECC lock or other failure
+        try:
+            public_keys = get_public_keys_rust()
+        except Exception as e:
+            diagnostics_report.record_failure(e, self)
+
+        # Record key value, or report failure if unable to parse
         try:
             diagnostics_report.record_result(public_keys[self.key_path], self)
-
         except KeyError:
             err_msg = "Key %s not found" % self.key_path
             diagnostics_report.record_failure(err_msg, self)

--- a/hw_diag/utilities/shell.py
+++ b/hw_diag/utilities/shell.py
@@ -1,6 +1,8 @@
 import subprocess
 import os
 
+from hm_pyhelper.lock_singleton import lock_ecc
+
 
 def get_environment_var(diagnostics):
     # The order of the values in the lists is important!
@@ -19,6 +21,7 @@ def get_environment_var(diagnostics):
         diagnostics[key] = os.getenv(var)
 
 
+@lock_ecc()
 def config_search_param(command, param):
     """
     input:


### PR DESCRIPTION
@posterzh, I don't mean to step on your toes, but wanted to get some thoughts on this approach. More work is needed on the hm-pyhelper side, even if we do decide to use this approach.

**Why**
ECC access sometimes fails. We suspect it might be because of concurrent access. This PR attempts to prevent concurrent access to the ECC.

**How**
Added LockSingleton to easily instantiate a new instance of a singleton
that is a wrapper around a threading.Lock. Use this singleton lock
whenever the ECC is accessed.

TODO:
- Move LockSingleton to hm-pyhelper
- Update hm-pythelper ecc methods to accept a lock as an optional
parameter. Acquire lock before using ECC, then release when done.

**References**
After completion, determine if this does close any of the below issues.

- https://github.com/NebraLtd/hm-diag/issues/194
- https://github.com/NebraLtd/hm-diag/issues/176
- https://github.com/NebraLtd/hm-diag/issues/167