### PR TITLE
fix: tolerate ECC errors

### DIFF
--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -9,10 +9,10 @@ from hw_diag.utilities.hardware import detect_ecc
 from hw_diag.utilities.hardware import get_rpi_serial
 from hw_diag.utilities.hardware import lora_module_test
 from hw_diag.utilities.hardware import set_diagnostics_bt_lte
+from hw_diag.utilities.hardware import get_public_keys_and_ignore_errors
 from hw_diag.utilities.miner import fetch_miner_data
 from hw_diag.utilities.shell import get_environment_var
 from hw_diag.utilities.gcs_shipper import upload_diagnostics
-from hm_pyhelper.miner_param import get_public_keys_rust
 
 
 log = logging.getLogger()
@@ -31,7 +31,7 @@ def perform_hw_diagnostics(ship=False):  # noqa: C901
     get_environment_var(diagnostics)
     get_rpi_serial(diagnostics)
     detect_ecc(diagnostics)
-    public_keys = get_public_keys_rust()
+    public_keys = get_public_keys_and_ignore_errors()
 
     diagnostics['LOR'] = lora_module_test()
     diagnostics['OK'] = public_keys['key']

--- a/hw_diag/tests/test_hardware.py
+++ b/hw_diag/tests/test_hardware.py
@@ -1,0 +1,24 @@
+import unittest
+from unittest.mock import patch
+from hw_diag.utilities.hardware import get_public_keys_and_ignore_errors # noqa
+
+
+class TestHardware(unittest.TestCase):
+    @patch('hw_diag.utilities.hardware.get_public_keys_rust')
+    def test_get_public_keys_no_error(self, mocked_get_public_keys_rust):
+        mocked_get_public_keys_rust.return_value = {
+            'key': 'foo',
+            'name': 'bar'
+        }
+        keys = get_public_keys_and_ignore_errors()
+
+        self.assertEqual(keys['key'], 'foo')
+        self.assertEqual(keys['name'], 'bar')
+
+    @patch('hw_diag.utilities.hardware.get_public_keys_rust')
+    def test_get_public_keys_with_error(self, mocked_get_public_keys_rust):
+        mocked_get_public_keys_rust.return_value = False
+        keys = get_public_keys_and_ignore_errors()
+
+        self.assertEqual(keys['key'], 'ECC failure')
+        self.assertEqual(keys['name'], 'ECC failure')

--- a/hw_diag/utilities/hardware.py
+++ b/hw_diag/utilities/hardware.py
@@ -99,7 +99,6 @@ def lora_module_test():
 
 def get_public_keys_and_ignore_errors():
     public_keys = get_public_keys_rust()
-    print("Public keys %s is %s" % (public_keys, not public_keys))
     if not public_keys:
         error_msg = "ECC failure"
         public_keys = {

--- a/hw_diag/utilities/hardware.py
+++ b/hw_diag/utilities/hardware.py
@@ -2,6 +2,7 @@ import logging
 import os
 from time import sleep
 
+from hm_pyhelper.miner_param import get_public_keys_rust
 from hm_pyhelper.hardware_definitions import variant_definitions
 from hw_diag.utilities.shell import config_search_param
 
@@ -94,3 +95,16 @@ def lora_module_test():
             sleep(10)
 
     return result
+
+
+def get_public_keys_and_ignore_errors():
+    public_keys = get_public_keys_rust()
+    print("Public keys %s is %s" % (public_keys, not public_keys))
+    if not public_keys:
+        error_msg = "ECC failure"
+        public_keys = {
+            'name': error_msg,
+            'key': error_msg
+        }
+
+    return public_keys


### PR DESCRIPTION
**Why**
Should be able to generate diagnostics report even if unable to retrieve public keys.

**How**
Diagnostics return values indicating error when ECC fails instead of causing a terminal error.

**References**
Closes: https://github.com/NebraLtd/hm-diag/issues/194
Related to: https://github.com/NebraLtd/hm-diag/issues/181