### PR TITLE
Lock ECC using LockSingleton from hm-pyhelper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ HEALTHCHECK \
 RUN \
     install_packages \
       i2c-tools \
-      usbutils
+      usbutils \
+      build-essential
 
 RUN mkdir /tmp/build
 COPY ./ /tmp/build

--- a/hw_diag/lock_singleton.py
+++ b/hw_diag/lock_singleton.py
@@ -1,0 +1,57 @@
+import functools
+import os
+import posix_ipc
+
+LOCK_ECC = 'LOCK_ECC'
+
+
+class LockSingleton(object):
+    _prefix = "LockSingleton."
+    _mode = 0o666
+
+    def __init__(self, name, initial_value=1):
+        self._name = self._prefix + name
+        # so it doesn't interfere with our semaphore mode
+        old_umask = os.umask(0)
+        try:
+            self._sem = posix_ipc.Semaphore(self._name,
+                                            mode=self._mode,
+                                            flags=posix_ipc.O_CREAT,
+                                            initial_value=initial_value)
+        finally:
+            os.umask(old_umask)
+
+    def acquire(self, timeout=None):
+        """Acquire the lock
+        """
+        try:
+            self._sem.acquire(timeout)
+        except posix_ipc.BusyError:
+            return False
+
+        return True
+
+    def release(self):
+        """Release the lock
+        """
+        self._sem.release()
+
+    def locked(self):
+        return self.value() == 0
+
+    def value(self):
+        return self._sem.value
+
+
+def ecc_lock(func):
+    """Returns an ECC LOCK decorator.
+    """
+    lock = LockSingleton(LOCK_ECC)
+
+    @functools.wraps(func)
+    def wrapper_ecc_lock(*args, **kwargs):
+        lock.acquire()
+        value = func(*args, **kwargs)
+        lock.release()
+        return value
+    return wrapper_ecc_lock

--- a/hw_diag/lock_singleton_demo.py
+++ b/hw_diag/lock_singleton_demo.py
@@ -1,0 +1,12 @@
+import time
+from hw_diag.lock_singleton import ecc_lock
+
+
+@ecc_lock
+def worker1():
+    print('Start working...')
+    time.sleep(5)
+    print('Work finished!')
+
+
+worker1()

--- a/hw_diag/utilities/hardware.py
+++ b/hw_diag/utilities/hardware.py
@@ -3,6 +3,8 @@ import os
 from time import sleep
 
 from hm_pyhelper.hardware_definitions import variant_definitions
+
+from hw_diag.lock_singleton import ecc_lock
 from hw_diag.utilities.shell import config_search_param
 
 
@@ -37,6 +39,7 @@ def set_diagnostics_bt_lte(diagnostics):
     return diagnostics
 
 
+@ecc_lock
 def detect_ecc(diagnostics):
     # The order of the values in the lists is important!
     # It determines which value will be available for which key

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ hm-pyhelper==0.8.12
 requests==2.26.0
 retry==0.9.2
 sentry-sdk==1.1.0
+posix-ipc==1.0.5


### PR DESCRIPTION
This is draft PR that uses `LockSingleton` class embedded in this PR. After https://github.com/NebraLtd/hm-pyhelper/pull/46/files gets approved and `hm-pyhelper` python package is released into https://pypi.org/, `LockSingleton` class needs to be updated with the one from `hm-pyhelper` package.

**Why**
To prevent ECC test fail, add the LockSingleton from hm-pyhelper.

**How**
Use @ecc_lock decorator at the function that calls the ECC feature.

**References**
https://github.com/NebraLtd/hm-diag/issues/167