### PR TITLE
refactor initFile and prevent 500s

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,14 @@ Because the stack is tightly intertwined with Balena, the easiest way to test th
 
 If you are on the same network as the Raspberry Pi, enter `LOCAL IP ADDRESS` from Balena into the browser.
 
+### Testing
+
+```
+pip install -r test-requirements.txt
+pytest
+flake8 hw_diag
+```
+
 ### Deprecated deployment
 This is no longer [the recommended way](https://www.balena.io/docs/learn/deploy/deployment/#overview) of doing Balena deployments.
 

--- a/hw_diag/diagnostics/bt_lte_diagnostic.py
+++ b/hw_diag/diagnostics/bt_lte_diagnostic.py
@@ -1,0 +1,71 @@
+import os
+from hm_pyhelper.diagnostics.diagnostic import Diagnostic
+
+
+DEVICE_TYPE_ADDRESS_MAPPINGS = [
+    {
+        'dev_type': 'BT',
+        'dev_addr': '0a12'
+    },
+    {
+        'dev_type': 'LTE',  # Quectel
+        'dev_addr': '2c7c'
+    },
+    {
+        'dev_type': 'LTE',  # Sierra Wireless MC7700
+        'dev_addr': '68a2'
+    },
+    {
+        'dev_type': 'LTE',  # Telit / Reyax
+        'dev_addr': '1bc7'
+    },
+    {
+        'dev_type': 'LTE',  # SimCom SIM7100E
+        'dev_addr': '1e0e'
+    },
+    {
+        'dev_type': 'LTE',  # Huawei ME909s-120
+        'dev_addr': '12d1'
+    },
+    {
+        'dev_type': 'LTE',  # MikroTik R11e-LTE6
+        'dev_addr': '2cd2'
+    }
+]
+
+
+class BtLteDiagnostic(Diagnostic):
+    def __init__(self, dev_type, dev_addr):
+        super(BtLteDiagnostic, self).__init__(dev_type, dev_type)
+        self.dev_addr = dev_addr
+
+    def perform_test(self, diagnostics_report):
+        resp = os.popen(
+            'grep %s /sys/bus/usb/devices/*/idVendor' % self.dev_addr
+        ).read()
+
+        if self.dev_addr in resp:
+            print("setting %s to %s" % (self.key, True))
+            diagnostics_report.record_result(True, self)
+        else:
+            # Only set the dev_type to False if it is not already true
+            if self.key not in diagnostics_report:
+                diagnostics_report.record_result(False, self)
+
+            dev_type_already_true = diagnostics_report[self.key]
+            if not dev_type_already_true:
+                diagnostics_report.record_result(False, self)
+
+
+class BtLteDiagnostics():
+    def __init__(self):
+        def get_diagnostic_for_dev(bt_lte_mapping):
+            return BtLteDiagnostic(bt_lte_mapping['dev_type'],
+                                   bt_lte_mapping['dev_addr'])
+
+        self.bt_lte_diagnostics = map(get_diagnostic_for_dev,
+                                      DEVICE_TYPE_ADDRESS_MAPPINGS)
+
+    def perform_test(self, diagnostics_report):
+        for bt_lte_diagnostic in self.bt_lte_diagnostics:
+            bt_lte_diagnostic.perform_test(diagnostics_report)

--- a/hw_diag/diagnostics/ecc_diagnostic.py
+++ b/hw_diag/diagnostics/ecc_diagnostic.py
@@ -1,0 +1,26 @@
+import json
+from hm_pyhelper.miner_param import get_gateway_mfr_test_result
+from hm_pyhelper.diagnostics.diagnostic import Diagnostic
+from hm_pyhelper.exceptions import ECCMalfunctionException
+
+KEY = 'ECC'
+FRIENDLY_NAME = "ECC"
+
+
+class EccDiagnostic(Diagnostic):
+    def __init__(self):
+        super(EccDiagnostic, self).__init__(KEY, FRIENDLY_NAME)
+
+    def perform_test(self, diagnostics_report):
+        try:
+            ecc_tests = get_gateway_mfr_test_result()
+
+            if ecc_tests['result'] == 'pass':
+                diagnostics_report.record_result(True, self)
+            else:
+                msg = "gateway_mfr test finished with error, %s" % \
+                      str(json.dumps(ecc_tests))
+                diagnostics_report.record_failure(msg, self)
+
+        except ECCMalfunctionException as e:
+            diagnostics_report.record_failure(str(e), self)

--- a/hw_diag/diagnostics/env_var_diagnostics.py
+++ b/hw_diag/diagnostics/env_var_diagnostics.py
@@ -1,0 +1,49 @@
+import os
+from hm_pyhelper.diagnostics.diagnostic import Diagnostic
+
+ENV_VARS_MAPPING = [{
+    'ENV_VAR': 'BALENA_DEVICE_NAME_AT_INIT',
+    'DIAGNOSTIC_KEY': 'BN'
+}, {
+    'ENV_VAR': 'BALENA_DEVICE_UUID',
+    'DIAGNOSTIC_KEY': 'ID'
+}, {
+    'ENV_VAR': 'BALENA_APP_NAME',
+    'DIAGNOSTIC_KEY': 'BA'
+}, {
+    'ENV_VAR': 'FREQ',
+    'DIAGNOSTIC_KEY': 'FR'
+}, {
+    'ENV_VAR': 'FIRMWARE_VERSION',
+    'DIAGNOSTIC_KEY': 'FW'
+}, {
+    'ENV_VAR': 'VARIANT',
+    'DIAGNOSTIC_KEY': 'VA'
+}]
+
+
+class EnvVarDiagnostic(Diagnostic):
+    def __init__(self, key, friendly_key):
+        super(EnvVarDiagnostic, self).__init__(key, friendly_key)
+
+    def perform_test(self, diagnostics_report):
+        env_value = os.getenv(self.friendly_key)
+        if not env_value:
+            diagnostics_report.record_failure(
+                "Env var %s not set" % self.friendly_key, self)
+        else:
+            diagnostics_report.record_result(env_value, self)
+
+
+class EnvVarDiagnostics():
+    def __init__(self):
+        def get_diagnostic_for_env_var(env_var_mapping):
+            return EnvVarDiagnostic(env_var_mapping['DIAGNOSTIC_KEY'],
+                                    env_var_mapping['ENV_VAR'])
+
+        self.env_var_diagnostics = map(get_diagnostic_for_env_var,
+                                       ENV_VARS_MAPPING)
+
+    def perform_test(self, diagnostics_report):
+        for env_var_diagnostic in self.env_var_diagnostics:
+            env_var_diagnostic.perform_test(diagnostics_report)

--- a/hw_diag/diagnostics/key_diagnostics.py
+++ b/hw_diag/diagnostics/key_diagnostics.py
@@ -1,0 +1,47 @@
+from hm_pyhelper.miner_param import get_public_keys_rust
+from hm_pyhelper.diagnostics.diagnostic import Diagnostic
+
+
+KEY_MAPPINGS = [
+    {
+        'key': 'OK',
+        'friendly_key': 'onboarding_key',
+        'key_path': 'key'
+    },
+    {
+        'key': 'PK',
+        'friendly_key': 'public_key',
+        'key_path': 'key'
+    }
+]
+
+
+class KeyDiagnostic(Diagnostic):
+    def __init__(self, key, friendly_key, key_path):
+        super(KeyDiagnostic, self).__init__(key, friendly_key)
+        self.key_path = key_path
+
+    def perform_test(self, diagnostics_report):
+        public_keys = get_public_keys_rust()
+        try:
+            diagnostics_report.record_result(public_keys[self.key_path], self)
+
+        except KeyError:
+            err_msg = "Key %s not found" % self.key_path
+            diagnostics_report.record_failure(err_msg, self)
+
+
+class KeyDiagnostics:
+    def __init__(self):
+        def get_diagnostic_for_key(key_mapping):
+            return KeyDiagnostic(
+              key_mapping['key'],
+              key_mapping['friendly_key'],
+              key_mapping['key_path'])
+
+        self.key_diagnostics = map(get_diagnostic_for_key,
+                                   KEY_MAPPINGS)
+
+    def perform_test(self, diagnostics_report):
+        for key_diagnostic in self.key_diagnostics:
+            key_diagnostic.perform_test(diagnostics_report)

--- a/hw_diag/diagnostics/lora_diagnostic.py
+++ b/hw_diag/diagnostics/lora_diagnostic.py
@@ -1,0 +1,16 @@
+from hm_pyhelper.diagnostics.diagnostic import Diagnostic
+from hw_diag.utilities.hardware import lora_module_test
+
+KEY = 'LOR'
+FRIENDLY_NAME = "lora"
+
+
+class LoraDiagnostic(Diagnostic):
+    def __init__(self):
+        super(LoraDiagnostic, self).__init__(KEY, FRIENDLY_NAME)
+
+    def perform_test(self, diagnostics_report):
+        if lora_module_test():
+            diagnostics_report.record_result(True, self)
+        else:
+            diagnostics_report.record_failure(False, self)

--- a/hw_diag/diagnostics/mac_diagnostics.py
+++ b/hw_diag/diagnostics/mac_diagnostics.py
@@ -1,0 +1,45 @@
+from hm_pyhelper.miner_param import get_mac_address
+from hm_pyhelper.diagnostics.diagnostic import Diagnostic
+
+
+INTERFACE_MAPPINGS = [
+  {
+    'key': 'E0',
+    'friendly_key': 'eth_mac_address',
+    'mac_filepath': '/sys/class/net/eth0/address'
+  },
+  {
+    'key': 'W0',
+    'friendly_key': 'wifi_mac_address',
+    'mac_filepath': '/sys/class/net/wlan0/address'
+  }
+]
+
+
+class MacDiagnostic(Diagnostic):
+    def __init__(self, key, friendly_key, mac_filepath):
+        super(MacDiagnostic, self).__init__(key, friendly_key)
+        self.mac_filepath = mac_filepath
+
+    def perform_test(self, diagnostics_report):
+        try:
+            mac_address = get_mac_address(self.mac_filepath)
+            diagnostics_report.record_result(mac_address, self)
+        except Exception as e:
+            diagnostics_report.record_failure(str(e), self)
+
+
+class MacDiagnostics():
+    def __init__(self):
+        def get_diagnostic_for_interface(interface_info):
+            return MacDiagnostic(
+              interface_info['key'],
+              interface_info['friendly_key'],
+              interface_info['mac_filepath'])
+
+        self.mac_diagnostics = map(get_diagnostic_for_interface,
+                                   INTERFACE_MAPPINGS)
+
+    def perform_test(self, diagnostics_report):
+        for mac_diagnostic in self.mac_diagnostics:
+            mac_diagnostic.perform_test(diagnostics_report)

--- a/hw_diag/diagnostics/pf_diagnostic.py
+++ b/hw_diag/diagnostics/pf_diagnostic.py
@@ -1,0 +1,22 @@
+from hm_pyhelper.diagnostics.diagnostic import Diagnostic
+
+KEY = 'PF'
+FRIENDLY_NAME = "legacy_pass_fail"
+CHECK_KEYS = ["ECC", "E0", "W0", "BT", "LOR"]
+
+
+class PfDiagnostic(Diagnostic):
+    def __init__(self):
+        super(PfDiagnostic, self).__init__(KEY, FRIENDLY_NAME)
+
+    def perform_test(self, diagnostics_report):
+        def get_result(key):
+            return key in diagnostics_report and \
+                   diagnostics_report[key]
+
+        all_passed = all(map(get_result, CHECK_KEYS))
+
+        if all_passed:
+            diagnostics_report.record_result(True, self)
+        else:
+            diagnostics_report.record_failure(False, self)

--- a/hw_diag/diagnostics/rpi_serial_diagnostic.py
+++ b/hw_diag/diagnostics/rpi_serial_diagnostic.py
@@ -1,0 +1,23 @@
+
+from hm_pyhelper.diagnostics.diagnostic import Diagnostic
+
+KEY = 'RPI'
+FRIENDLY_NAME = "raspberry_pi_serial_number"
+SERIAL_FILEPATH = "/proc/cpuinfo"
+
+
+class RpiSerialDiagnostic(Diagnostic):
+    def __init__(self):
+        super(RpiSerialDiagnostic, self). \
+            __init__(KEY, FRIENDLY_NAME)
+
+    def perform_test(self, diagnostics_report):
+        try:
+            rpi_serial = open(SERIAL_FILEPATH).readlines()[-2].strip()[10:]
+            diagnostics_report.record_result(rpi_serial, self)
+
+        except FileNotFoundError as e:
+            diagnostics_report.record_failure(e, self)
+
+        except PermissionError as e:
+            diagnostics_report.record_failure(e, self)

--- a/hw_diag/tests/diagnostics/test_bt_lte_diagnostics.py
+++ b/hw_diag/tests/diagnostics/test_bt_lte_diagnostics.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import patch
+
+from hm_pyhelper.diagnostics.diagnostics_report import \
+    DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+
+from hw_diag.diagnostics.bt_lte_diagnostic import \
+    BtLteDiagnostic, BtLteDiagnostics
+
+
+class TestBtLteDiagnostics(unittest.TestCase):
+    @patch('os.popen')
+    def test_success(self, mock):
+        mock().read.return_value = 'dev_addr'
+        diagnostic = BtLteDiagnostic('DEV_TYPE', 'dev_addr')
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'DEV_TYPE': True
+        })
+
+    @patch('os.popen')
+    def test_error(self, mock):
+        mock().read.return_value = 'INVALID'
+        diagnostic = BtLteDiagnostic('DEV_TYPE', 'dev_addr')
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'DEV_TYPE': False
+        })
+
+    @patch('os.popen')
+    def test_all_success(self, mock):
+        mock().read.return_value = '0a12, 2c7c, 68a2, 1bc7, 1e0e, 12d1, 2cd2'
+
+        diagnostic = BtLteDiagnostics()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'BT': True,
+            'LTE': True,
+        })

--- a/hw_diag/tests/diagnostics/test_ecc_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_ecc_diagnostic.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import patch
+
+from hm_pyhelper.diagnostics.diagnostics_report import \
+    DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+from hw_diag.diagnostics.ecc_diagnostic import EccDiagnostic
+from hm_pyhelper.exceptions import ECCMalfunctionException
+
+
+class TestECCDiagnostic(unittest.TestCase):
+    @patch(
+      "hw_diag.diagnostics.ecc_diagnostic.get_gateway_mfr_test_result",
+      return_value={'result': 'pass'})
+    def test_success(self, mock):
+        diagnostic = EccDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'ECC': True
+        })
+
+    @patch(
+      "hw_diag.diagnostics.ecc_diagnostic.get_gateway_mfr_test_result",
+      return_value={'result': 'fail'})
+    def test_failure(self, mock):
+        diagnostic = EccDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['ECC'],
+            'ECC': 'gateway_mfr test finished with error, {"result": "fail"}'
+        })
+
+    @patch(
+        "hw_diag.diagnostics.ecc_diagnostic.get_gateway_mfr_test_result",
+        side_effect=ECCMalfunctionException("ECC Malfunctioned"))
+    def test_exception(self, mock):
+        diagnostic = EccDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['ECC'],
+            'ECC': 'ECC Malfunctioned'
+        })

--- a/hw_diag/tests/diagnostics/test_env_var_diagnostics.py
+++ b/hw_diag/tests/diagnostics/test_env_var_diagnostics.py
@@ -1,0 +1,60 @@
+import unittest
+import os
+from hm_pyhelper.diagnostics.diagnostics_report import \
+    DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+
+from hw_diag.diagnostics.env_var_diagnostics import \
+    EnvVarDiagnostic, EnvVarDiagnostics, ENV_VARS_MAPPING
+
+
+class TestEnvVarDiagnostics(unittest.TestCase):
+    def test_success(self):
+        os.environ['ENV_VAR'] = 'foo'
+        diagnostic = EnvVarDiagnostic('DIAGNOSTIC_KEY', 'ENV_VAR')
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'DIAGNOSTIC_KEY': 'foo',
+            'ENV_VAR': 'foo'
+        })
+
+    def test_error(self):
+        os.environ['ENV_VAR'] = ''
+        diagnostic = EnvVarDiagnostic('DIAGNOSTIC_KEY', 'ENV_VAR')
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['DIAGNOSTIC_KEY'],
+            'DIAGNOSTIC_KEY': 'Env var ENV_VAR not set',
+            'ENV_VAR': 'Env var ENV_VAR not set'
+        })
+
+    def test_env_vars_success(self):
+        for mapping in ENV_VARS_MAPPING:
+            os.environ[mapping['ENV_VAR']] = 'foo'
+
+        diagnostic = EnvVarDiagnostics()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'BALENA_DEVICE_NAME_AT_INIT': 'foo',
+            'BN': 'foo',
+            'BALENA_DEVICE_UUID': 'foo',
+            'ID': 'foo',
+            'BALENA_APP_NAME': 'foo',
+            'BA': 'foo',
+            'FREQ': 'foo',
+            'FR': 'foo',
+            'FIRMWARE_VERSION': 'foo',
+            'FW': 'foo',
+            'VARIANT': 'foo',
+            'VA': 'foo'
+        })

--- a/hw_diag/tests/diagnostics/test_key_diagnostics.py
+++ b/hw_diag/tests/diagnostics/test_key_diagnostics.py
@@ -1,0 +1,55 @@
+import unittest
+from unittest.mock import patch
+
+from hm_pyhelper.diagnostics.diagnostics_report import \
+    DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+from hw_diag.diagnostics.key_diagnostics import KeyDiagnostic, KeyDiagnostics
+
+
+class TestKeyDiagnostics(unittest.TestCase):
+    @patch(
+      "hw_diag.diagnostics.key_diagnostics.get_public_keys_rust",
+      return_value={'key_location': '123'})
+    def test_success(self, mock):
+        diagnostic = KeyDiagnostic('KK', 'test_key', 'key_location')
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'KK': '123',
+            'test_key': '123'
+        })
+
+    @patch(
+      "hw_diag.diagnostics.key_diagnostics.get_public_keys_rust",
+      return_value={'different_location': '123'})
+    def test_failure(self, mock):
+        diagnostic = KeyDiagnostic('KK', 'test_key', 'key_location')
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['KK'],
+            'KK': 'Key key_location not found',
+            'test_key': 'Key key_location not found'
+        })
+
+    @patch(
+      "hw_diag.diagnostics.key_diagnostics.get_public_keys_rust",
+      return_value={'key': '123'})
+    def test_keys_success(self, mock):
+        diagnostic = KeyDiagnostics()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'PK': '123',
+            'public_key': '123',
+            'OK': '123',
+            'onboarding_key': '123'
+        })

--- a/hw_diag/tests/diagnostics/test_lora_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_lora_diagnostic.py
@@ -1,0 +1,38 @@
+import unittest
+from unittest.mock import patch
+
+from hm_pyhelper.diagnostics.diagnostics_report import \
+    DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+from hw_diag.diagnostics.lora_diagnostic import LoraDiagnostic
+
+
+class TestLoraDiagnostic(unittest.TestCase):
+    @patch(
+      "hw_diag.diagnostics.lora_diagnostic.lora_module_test",
+      return_value=True)
+    def test_success(self, mock):
+        diagnostic = LoraDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'LOR': True,
+            'lora': True
+        })
+
+    @patch(
+      "hw_diag.diagnostics.lora_diagnostic.lora_module_test",
+      return_value=False)
+    def test_failure(self, mock):
+        diagnostic = LoraDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['LOR'],
+            'LOR': False,
+            'lora': False
+        })

--- a/hw_diag/tests/diagnostics/test_mac_diagnostics.py
+++ b/hw_diag/tests/diagnostics/test_mac_diagnostics.py
@@ -1,0 +1,53 @@
+import unittest
+from unittest.mock import patch, mock_open
+from hm_pyhelper.diagnostics.diagnostics_report import \
+    DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+
+from hw_diag.diagnostics.mac_diagnostics import MacDiagnostic, MacDiagnostics
+
+
+class TestMacDiagnostics(unittest.TestCase):
+    @patch("hw_diag.diagnostics.mac_diagnostics.get_mac_address",
+           return_value='foo')
+    def test_success(self, mock):
+        diagnostic = MacDiagnostic('I0', 'friendly', '/')
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'I0': 'foo',
+            'friendly': 'foo'
+        })
+
+    @patch("hw_diag.diagnostics.mac_diagnostics.get_mac_address",
+           new_callable=mock_open)
+    def test_error(self, mock):
+        mock.side_effect = Exception('No file')
+        diagnostic = MacDiagnostic('I0', 'friendly', '/')
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['I0'],
+            'I0': 'No file',
+            'friendly': 'No file'
+        })
+
+    @patch("hw_diag.diagnostics.mac_diagnostics.get_mac_address",
+           return_value='foo')
+    def test_macs_success(self, mock):
+        diagnostic = MacDiagnostics()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'E0': 'foo',
+            'eth_mac_address': 'foo',
+            'W0': 'foo',
+            'wifi_mac_address': 'foo'
+        })

--- a/hw_diag/tests/diagnostics/test_pf_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_pf_diagnostic.py
@@ -1,0 +1,39 @@
+import unittest
+
+from hm_pyhelper.diagnostics.diagnostics_report import \
+    DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+from hw_diag.diagnostics.pf_diagnostic import PfDiagnostic, CHECK_KEYS
+
+
+class TestPfDiagnostic(unittest.TestCase):
+    def test_success(self):
+        diagnostic = PfDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        for key in CHECK_KEYS:
+            diagnostics_report[key] = True
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'PF': True,
+            'legacy_pass_fail': True,
+            'BT': True,
+            'E0': True,
+            'ECC': True,
+            'LOR': True,
+            'PF': True,
+            'W0': True,
+        })
+
+    def test_failure(self):
+        diagnostic = PfDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['PF'],
+            'PF': False,
+            'legacy_pass_fail': False,
+        })

--- a/hw_diag/tests/diagnostics/test_rpi_serial_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_rpi_serial_diagnostic.py
@@ -1,0 +1,56 @@
+import unittest
+from unittest.mock import patch, mock_open
+
+from hm_pyhelper.diagnostics.diagnostics_report import \
+    DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+from hw_diag.diagnostics.rpi_serial_diagnostic import RpiSerialDiagnostic
+
+VALID_CPU_PROC = """Hardware	: BCM2835
+Revision	: a02100
+Serial		: 00000000ddd1a4c2
+Model		: Raspberry Pi Compute Module 3 Plus Rev 1.0
+"""
+
+
+class TestRpiSerialDiagnostic(unittest.TestCase):
+
+    @patch("builtins.open", new_callable=mock_open, read_data=VALID_CPU_PROC)
+    def test_success(self, mock):
+        diagnostic = RpiSerialDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'RPI': '00000000ddd1a4c2',
+            'raspberry_pi_serial_number': '00000000ddd1a4c2'
+        })
+
+    @patch("builtins.open", new_callable=mock_open)
+    def test_filenotfound(self, mock):
+        mock.side_effect = FileNotFoundError("File not found")
+        diagnostic = RpiSerialDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['RPI'],
+            'RPI': 'File not found',
+            'raspberry_pi_serial_number': 'File not found'
+        })
+
+    @patch("builtins.open", new_callable=mock_open)
+    def test_permissionerror(self, mock):
+        mock.side_effect = PermissionError("Bad permissions")
+        diagnostic = RpiSerialDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['RPI'],
+            'RPI': 'Bad permissions',
+            'raspberry_pi_serial_number': 'Bad permissions'
+        })

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask==2.0.1
 certifi==2021.5.30
 click==7.1.2
 gunicorn==20.1.0
-hm-pyhelper==0.11.2
+hm-pyhelper==0.11.3
 requests==2.26.0
 retry==0.9.2
 sentry-sdk==1.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ Flask==2.0.1
 certifi==2021.5.30
 click==7.1.2
 gunicorn==20.1.0
-hm-pyhelper==0.8.12
+hm-pyhelper==0.11.2
 requests==2.26.0
 retry==0.9.2
 sentry-sdk==1.1.0

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,13 @@ import os
 base_name = 'hw_diag'
 
 # allow setup.py to be run from any path
-os.chdir(os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir)))
+here = os.path.normpath(os.path.join(os.path.abspath(__file__), os.pardir))
+os.chdir(here)
+
+requires = [
+    line.strip()
+    for line in open(os.path.join(here, "requirements.txt"), "r").readlines()
+]
 
 setup(
     name=base_name,
@@ -19,20 +25,12 @@ setup(
     long_description="",
     zip_safe=False,
 
-    entry_points={'console_scripts': [
-        'hm_diag = hw_diag.app:main', ], },
+    entry_points={
+        'console_scripts': [
+            'hm_diag = hw_diag.app:main',
+        ],
+    },
 
     # Adds dependencies
-    install_requires=['Flask==2.0.1',
-                      'Flask-APScheduler==1.12.2',
-                      'Flask-Caching==1.10.1',
-                      'requests==2.26.0',
-                      'hm-pyhelper==0.4',
-                      'click==7.1.2',
-                      'certifi==2021.5.30',
-                      'gunicorn==20.1.0',
-                      'hm-pyhelper==0.8.13',
-                      'retry==0.9.2',
-                      'sentry-sdk==1.1.0'
-                      ]
+    install_requires=requires
 )

--- a/setup.py
+++ b/setup.py
@@ -25,8 +25,14 @@ setup(
     # Adds dependencies
     install_requires=['Flask==2.0.1',
                       'Flask-APScheduler==1.12.2',
+                      'Flask-Caching==1.10.1',
                       'requests==2.26.0',
                       'hm-pyhelper==0.4',
-                      'click==7.1.2'
+                      'click==7.1.2',
+                      'certifi==2021.5.30',
+                      'gunicorn==20.1.0',
+                      'hm-pyhelper==0.8.13',
+                      'retry==0.9.2',
+                      'sentry-sdk==1.1.0'
                       ]
 )

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,0 +1,2 @@
+pytest
+flake8


### PR DESCRIPTION
**Why**
The initFile should always return something, even if the miner is not fully operational. 

**How**
Created DiagnosticsReport and Diagnostic concepts for each test we do on the miner.
Each Diagnostic must add a value to the report and cannot cause the report to fail.

The [tests](https://github.com/NebraLtd/hm-diag/pull/201/files#diff-b4c69b275920e57eaa26df2f0192bfc5ab6201d3a1e3583ee590ff3509540963R46) are helpful for understanding what the final output looks like.

**Next steps**
- Add more helpful error messages. Eg still swallowing some info when keys fail
- Update Hotspot-Production-Tool according to this logic
- Move DiagnosticsReport and Diagnostic to hm-pyhelper.
- Remove/update methods in hm-pyhelper that accept `diagnostics` as a parameter.
- Update `perform_hw_diagnostics` to use the same pattern.

**References**
- Closes: https://github.com/NebraLtd/hm-diag/issues/181
- Related to: https://github.com/NebraLtd/Hotspot-Production-Tool/issues/9
- Fixes: https://github.com/NebraLtd/hm-diag/issues/194 and supercedes: https://github.com/NebraLtd/hm-diag/pull/199
