### PR TITLE
Fix: Add timeout to request on helium api

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
     build: .
     environment:
       - 'FIRMWARE_VERSION=2021.08.02.0'
-      - 'DEFAULT_TIMEOUT=5'
+      - 'HELIUM_API_TIMEOUT_SECONDS=5'
     volumes:
       - 'pktfwdr:/var/pktfwd'
       - 'miner-storage:/var/data'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     build: .
     environment:
       - 'FIRMWARE_VERSION=2021.08.02.0'
+      - 'DEFAULT_TIMEOUT=5'
     volumes:
       - 'pktfwdr:/var/pktfwd'
       - 'miner-storage:/var/data'

--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -49,7 +49,7 @@ def perform_hw_diagnostics(ship=False):  # noqa: C901
         log.exception(e)
 
     # Get the blockchain height from the Helium API
-    value = "1"
+    value = "Not Available"
     try:
         value = get_helium_blockchain_height()
     except KeyError as e:
@@ -69,6 +69,9 @@ def perform_hw_diagnostics(ship=False):  # noqa: C901
     diag_mh = int(diagnostics['MH'])
     diag_bch = int(diagnostics['BCH'])
     diagnostics['BSP'] = round(diag_mh / diag_bch * 100, 3)
+    
+    if value == "Not Available":
+        diagnostics['BSP'] = "Not Available"
 
     set_diagnostics_bt_lte(diagnostics)
 

--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -49,14 +49,14 @@ def perform_hw_diagnostics(ship=False):  # noqa: C901
         log.exception(e)
 
     # Get the blockchain height from the Helium API
-    value = "Not Available"
+    value = "1"
     try:
         value = get_helium_blockchain_height()
     except KeyError as e:
         logging.warning(e)
-    except (ConnectTimeout, ReadTimeout) as e:
+    except (ConnectTimeout, ReadTimeout):
         err_str = ("Request to Helium API timed out."
-            " Will fallback to block height of 1.")
+                   " Will fallback to block height of 1.")
         logging.exception(err_str)
     diagnostics['BCH'] = value
 
@@ -71,9 +71,6 @@ def perform_hw_diagnostics(ship=False):  # noqa: C901
     diag_mh = int(diagnostics['MH'])
     diag_bch = int(diagnostics['BCH'])
     diagnostics['BSP'] = round(diag_mh / diag_bch * 100, 3)
-
-    if value == "Not Available":
-        diagnostics['BSP'] = "Not Available"
 
     set_diagnostics_bt_lte(diagnostics)
 

--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -55,7 +55,9 @@ def perform_hw_diagnostics(ship=False):  # noqa: C901
     except KeyError as e:
         logging.warning(e)
     except (ConnectTimeout, ReadTimeout) as e:
-        logging.exception(e)
+        err_str = ("Request to Helium API timed out."
+            " Will fallback to block height of 1.")
+        logging.exception(err_str)
     diagnostics['BCH'] = value
 
     # Check if the miner height
@@ -69,7 +71,7 @@ def perform_hw_diagnostics(ship=False):  # noqa: C901
     diag_mh = int(diagnostics['MH'])
     diag_bch = int(diagnostics['BCH'])
     diagnostics['BSP'] = round(diag_mh / diag_bch * 100, 3)
-    
+
     if value == "Not Available":
         diagnostics['BSP'] = "Not Available"
 

--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -14,6 +14,7 @@ from hw_diag.utilities.miner import fetch_miner_data
 from hw_diag.utilities.shell import get_environment_var
 from hw_diag.utilities.gcs_shipper import upload_diagnostics
 from hm_pyhelper.miner_json_rpc.exceptions import MinerFailedFetchData
+from requests.exceptions import ConnectTimeout, ReadTimeout
 
 
 log = logging.getLogger()
@@ -53,6 +54,8 @@ def perform_hw_diagnostics(ship=False):  # noqa: C901
         value = get_helium_blockchain_height()
     except KeyError as e:
         logging.warning(e)
+    except (ConnectTimeout, ReadTimeout) as e:
+        logging.exception(e)
     diagnostics['BCH'] = value
 
     # Check if the miner height

--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -48,13 +48,19 @@
                   <td>Sync Percentage</td>
                   {% if diagnostics.BSP > 99.98 %}
                     <td class="text-right">100%</td>
+                  {% elif diagnostics.BSP == -100.00 %}
+                    <td class="text-right">Not Available</td>
                   {% else %}
                     <td class="text-right">{{ '%0.2f' % diagnostics.BSP|float }}%</td>
                   {% endif %}
                 </tr>
                 <tr>
                   <td>Height Status</td>
-                  <td class="text-right">{{ diagnostics.MH }} / {{ diagnostics.BCH }}</td>
+                  {% if diagnostics.MH == -1 %}
+                    <td class="text-right">Not Available</td>
+                  {% else %}
+                    <td class="text-right">{{ diagnostics.MH }} / {{ diagnostics.BCH }}</td>
+                  {% endif %}
                 </tr>
                 <tr>
                   <td>Firmware Version</td>

--- a/hw_diag/tests/test_blockchain_helium_height.py
+++ b/hw_diag/tests/test_blockchain_helium_height.py
@@ -1,4 +1,3 @@
-import os
 import unittest
 from requests.exceptions import ConnectTimeout, ReadTimeout
 from unittest.mock import patch, Mock

--- a/hw_diag/tests/test_blockchain_helium_height.py
+++ b/hw_diag/tests/test_blockchain_helium_height.py
@@ -1,11 +1,11 @@
 import unittest
+from requests.exceptions import Timeout
 from unittest.mock import patch, Mock
 from requests.models import Response
 import sys
 import json
 sys.path.append("..")
 from hw_diag.utilities.blockchain import get_helium_blockchain_height # noqa
-from requests.exceptions import Timeout
 
 
 class TestHelium(unittest.TestCase):

--- a/hw_diag/tests/test_blockchain_helium_height.py
+++ b/hw_diag/tests/test_blockchain_helium_height.py
@@ -5,6 +5,7 @@ import sys
 import json
 sys.path.append("..")
 from hw_diag.utilities.blockchain import get_helium_blockchain_height # noqa
+from requests.exceptions import Timeout
 
 
 class TestHelium(unittest.TestCase):
@@ -43,3 +44,9 @@ class TestHelium(unittest.TestCase):
     @patch('requests.get', return_value=the_response)
     def test_wrong_data(self, _):
         self.assertRaises(KeyError, get_helium_blockchain_height)
+
+    @patch(
+        "requests.get",
+        side_effect=Timeout("Timeout Error"))
+    def test_timeout_exception(self, _):
+        self.assertRaises(Timeout, get_helium_blockchain_height)

--- a/hw_diag/tests/test_blockchain_helium_height.py
+++ b/hw_diag/tests/test_blockchain_helium_height.py
@@ -20,8 +20,6 @@ class TestHelium(unittest.TestCase):
     the_response.json.return_value = get_data
     the_response.status_code = 200
 
-    os.environ['DEFAULT_TIMEOUT'] = '5'
-
     @patch('requests.get', return_value=the_response)
     def test_successful_request(self, _):
         res = get_helium_blockchain_height()

--- a/hw_diag/tests/test_blockchain_helium_height.py
+++ b/hw_diag/tests/test_blockchain_helium_height.py
@@ -1,3 +1,4 @@
+import os
 import unittest
 from requests.exceptions import ConnectTimeout, ReadTimeout
 from unittest.mock import patch, Mock
@@ -18,6 +19,8 @@ class TestHelium(unittest.TestCase):
     the_response = Mock(spec=Response)
     the_response.json.return_value = get_data
     the_response.status_code = 200
+
+    os.environ['DEFAULT_TIMEOUT'] = '5'
 
     @patch('requests.get', return_value=the_response)
     def test_successful_request(self, _):

--- a/hw_diag/tests/test_blockchain_helium_height.py
+++ b/hw_diag/tests/test_blockchain_helium_height.py
@@ -1,5 +1,5 @@
 import unittest
-from requests.exceptions import Timeout
+from requests.exceptions import ConnectTimeout, ReadTimeout
 from unittest.mock import patch, Mock
 from requests.models import Response
 import sys
@@ -47,6 +47,12 @@ class TestHelium(unittest.TestCase):
 
     @patch(
         "requests.get",
-        side_effect=Timeout("Timeout Error"))
-    def test_timeout_exception(self, _):
-        self.assertRaises(Timeout, get_helium_blockchain_height)
+        side_effect=ConnectTimeout("Connect Timeout Error"))
+    def test_connecttimeout_exception(self, _):
+        self.assertRaises(ConnectTimeout, get_helium_blockchain_height)
+
+    @patch(
+        "requests.get",
+        side_effect=ReadTimeout("Connect Timeout Error"))
+    def test_readtimeout_exception(self, _):
+        self.assertRaises(ReadTimeout, get_helium_blockchain_height)

--- a/hw_diag/utilities/blockchain.py
+++ b/hw_diag/utilities/blockchain.py
@@ -10,7 +10,7 @@ def get_helium_blockchain_height():
     TypeError - if the key ['data']['height'] in response is not found.
     """
     try:
-        result = requests.get('https://api.helium.io/v1/blocks/height',\
+        result = requests.get('https://api.helium.io/v1/blocks/height',
                               timeout=5)
         if result.status_code == 200:
             result = result.json()
@@ -21,6 +21,6 @@ def get_helium_blockchain_height():
                     "Not found value from key ['data']['height'] in json"
                 )
             return result
-    except (requests.exceptions.ConnectTimeout,\
+    except (requests.exceptions.ConnectTimeout,
             requests.exceptions.ReadTimeout):
         raise

--- a/hw_diag/utilities/blockchain.py
+++ b/hw_diag/utilities/blockchain.py
@@ -11,7 +11,7 @@ def get_helium_blockchain_height():
     TypeError - if the key ['data']['height'] in response is not found.
     """
     result = requests.get('https://api.helium.io/v1/blocks/height',
-                            timeout=os.environ['DEFAULT_TIMEOUT'])
+                          timeout=os.getenv('HELIUM_API_TIMEOUT_SECONDS', 5))
     if result.status_code == 200:
         result = result.json()
         try:

--- a/hw_diag/utilities/blockchain.py
+++ b/hw_diag/utilities/blockchain.py
@@ -1,6 +1,5 @@
 import requests
 
-
 def get_helium_blockchain_height():
     """
     Get the blockchain height from the Helium API
@@ -9,13 +8,16 @@ def get_helium_blockchain_height():
     Possible exceptions:
     TypeError - if the key ['data']['height'] in response is not found.
     """
-    result = requests.get('https://api.helium.io/v1/blocks/height', timeout=5)
-    if result.status_code == 200:
-        result = result.json()
-        try:
-            result = result['data']['height']
-        except KeyError:
-            raise KeyError(
-                "Not found value from key ['data']['height'] in json"
-            )
-        return result
+    try:
+        result = requests.get('https://api.helium.io/v1/blocks/height', timeout=5)
+        if result.status_code == 200:
+            result = result.json()
+            try:
+                result = result['data']['height']
+            except KeyError:
+                raise KeyError(
+                    "Not found value from key ['data']['height'] in json"
+                )
+            return result
+    except (requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout):
+        raise 

--- a/hw_diag/utilities/blockchain.py
+++ b/hw_diag/utilities/blockchain.py
@@ -1,5 +1,6 @@
 import requests
 
+
 def get_helium_blockchain_height():
     """
     Get the blockchain height from the Helium API
@@ -9,7 +10,8 @@ def get_helium_blockchain_height():
     TypeError - if the key ['data']['height'] in response is not found.
     """
     try:
-        result = requests.get('https://api.helium.io/v1/blocks/height', timeout=5)
+        result = requests.get('https://api.helium.io/v1/blocks/height',\
+                              timeout=5)
         if result.status_code == 200:
             result = result.json()
             try:
@@ -19,5 +21,6 @@ def get_helium_blockchain_height():
                     "Not found value from key ['data']['height'] in json"
                 )
             return result
-    except (requests.exceptions.ConnectTimeout, requests.exceptions.ReadTimeout):
-        raise 
+    except (requests.exceptions.ConnectTimeout,\
+            requests.exceptions.ReadTimeout):
+        raise

--- a/hw_diag/utilities/blockchain.py
+++ b/hw_diag/utilities/blockchain.py
@@ -1,4 +1,5 @@
 import requests
+import os
 
 
 def get_helium_blockchain_height():
@@ -9,18 +10,14 @@ def get_helium_blockchain_height():
     Possible exceptions:
     TypeError - if the key ['data']['height'] in response is not found.
     """
-    try:
-        result = requests.get('https://api.helium.io/v1/blocks/height',
-                              timeout=5)
-        if result.status_code == 200:
-            result = result.json()
-            try:
-                result = result['data']['height']
-            except KeyError:
-                raise KeyError(
-                    "Not found value from key ['data']['height'] in json"
-                )
-            return result
-    except (requests.exceptions.ConnectTimeout,
-            requests.exceptions.ReadTimeout):
-        raise
+    result = requests.get('https://api.helium.io/v1/blocks/height',
+                            timeout=os.environ['DEFAULT_TIMEOUT'])
+    if result.status_code == 200:
+        result = result.json()
+        try:
+            result = result['data']['height']
+        except KeyError:
+            raise KeyError(
+                "Not found value from key ['data']['height'] in json"
+            )
+        return result

--- a/hw_diag/utilities/blockchain.py
+++ b/hw_diag/utilities/blockchain.py
@@ -9,7 +9,7 @@ def get_helium_blockchain_height():
     Possible exceptions:
     TypeError - if the key ['data']['height'] in response is not found.
     """
-    result = requests.get('https://api.helium.io/v1/blocks/height')
+    result = requests.get('https://api.helium.io/v1/blocks/height', timeout=5)
     if result.status_code == 200:
         result = result.json()
         try:

--- a/hw_diag/utilities/miner.py
+++ b/hw_diag/utilities/miner.py
@@ -14,7 +14,7 @@ def fetch_miner_data(diagnostics):
         LOGGER.exception(err)
         diagnostics['MC'] = "Failed to Fetch"
         diagnostics['MD'] = "Failed to Fetch"
-        diagnostics['MH'] = ""
+        diagnostics['MH'] = -1
         diagnostics['MN'] = "Failed to Fetch"
         diagnostics['MR'] = "Failed to Fetch"
         return diagnostics
@@ -22,7 +22,7 @@ def fetch_miner_data(diagnostics):
         LOGGER.exception(err)
         diagnostics['MC'] = "Failed to Fetch"
         diagnostics['MD'] = "Failed to Fetch"
-        diagnostics['MH'] = ""
+        diagnostics['MH'] = -1
         diagnostics['MN'] = "Failed to Fetch"
         diagnostics['MR'] = "Failed to Fetch"
         return diagnostics

--- a/hw_diag/utilities/miner.py
+++ b/hw_diag/utilities/miner.py
@@ -14,7 +14,7 @@ def fetch_miner_data(diagnostics):
         LOGGER.exception(err)
         diagnostics['MC'] = "Failed to Fetch"
         diagnostics['MD'] = "Failed to Fetch"
-        diagnostics['MH'] = -1
+        diagnostics['MH'] = ""
         diagnostics['MN'] = "Failed to Fetch"
         diagnostics['MR'] = "Failed to Fetch"
         return diagnostics
@@ -22,7 +22,7 @@ def fetch_miner_data(diagnostics):
         LOGGER.exception(err)
         diagnostics['MC'] = "Failed to Fetch"
         diagnostics['MD'] = "Failed to Fetch"
-        diagnostics['MH'] = -1
+        diagnostics['MH'] = ""
         diagnostics['MN'] = "Failed to Fetch"
         diagnostics['MR'] = "Failed to Fetch"
         return diagnostics


### PR DESCRIPTION
**Why**
Helium API is timing out, stuck on connecting to API while it's down

**How**
Added a timeout to the request and the dashboard served perfectly after this and displayed the timeout error

**References**
[Issue](https://github.com/NebraLtd/hm-diag/issues/216)