### PR TITLE
fix: diagnostics pass without W0 or LOR

### DIFF
--- a/hw_diag/diagnostics/pf_diagnostic.py
+++ b/hw_diag/diagnostics/pf_diagnostic.py
@@ -2,7 +2,7 @@ from hm_pyhelper.diagnostics.diagnostic import Diagnostic
 
 KEY = 'PF'
 FRIENDLY_NAME = "legacy_pass_fail"
-CHECK_KEYS = ["ECC", "E0", "W0", "BT", "LOR"]
+CHECK_KEYS = ["ECC", "E0", "BT"]
 
 
 class PfDiagnostic(Diagnostic):

--- a/hw_diag/tests/diagnostics/test_pf_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_pf_diagnostic.py
@@ -21,9 +21,7 @@ class TestPfDiagnostic(unittest.TestCase):
             'BT': True,
             'E0': True,
             'ECC': True,
-            'LOR': True,
             'PF': True,
-            'W0': True,
         })
 
     def test_failure(self):


### PR DESCRIPTION
**Why**
We temporarily want diagnostics to pass without LOR while we work
on startup logic for manufacturing. W0 will be addressed later. We
forgot to make this change as part of earlier work.

**How**
PF only considers ECC, E0, and BT
