### PR TITLE
fix: handle bad response for helium height

### DIFF
--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -62,7 +62,7 @@ def perform_hw_diagnostics(ship=False):  # noqa: C901
 
     # Check if the miner height
     # is within 500 blocks and if so say it's synced
-    if diagnostics['BCH'] is None:
+    if diagnostics['BCH'] is None or diagnostics['MH'] is None:
         diagnostics['MS'] = False
     elif int(diagnostics['MH']) > (int(diagnostics['BCH']) - 500):
         diagnostics['MS'] = True
@@ -70,7 +70,7 @@ def perform_hw_diagnostics(ship=False):  # noqa: C901
         diagnostics['MS'] = False
 
     # Calculate a percentage for block sync
-    if diagnostics['BCH'] is None:
+    if diagnostics['BCH'] is None or diagnostics['MH'] is None:
         diagnostics['BSP'] = None
     else:
         diag_mh = int(diagnostics['MH'])

--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -62,15 +62,20 @@ def perform_hw_diagnostics(ship=False):  # noqa: C901
 
     # Check if the miner height
     # is within 500 blocks and if so say it's synced
-    if int(diagnostics['MH']) > (int(diagnostics['BCH']) - 500):
+    if diagnostics['BCH'] is None:
+        diagnostics['MS'] = False
+    elif int(diagnostics['MH']) > (int(diagnostics['BCH']) - 500):
         diagnostics['MS'] = True
     else:
         diagnostics['MS'] = False
 
     # Calculate a percentage for block sync
-    diag_mh = int(diagnostics['MH'])
-    diag_bch = int(diagnostics['BCH'])
-    diagnostics['BSP'] = round(diag_mh / diag_bch * 100, 3)
+    if diagnostics['BCH'] is None:
+        diagnostics['BSP'] = None
+    else:
+        diag_mh = int(diagnostics['MH'])
+        diag_bch = int(diagnostics['BCH'])
+        diagnostics['BSP'] = round(diag_mh / diag_bch * 100, 3)
 
     set_diagnostics_bt_lte(diagnostics)
 

--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -48,8 +48,10 @@
                   <td>Sync Percentage</td>
                   {% if diagnostics.BSP > 99.98 %}
                     <td class="text-right">100%</td>
-                  {% elif diagnostics.BSP < 0 %}
+                  {% elif diagnostics.BSP == -100.00 %}
                     <td class="text-right">Not Available</td>
+                  {% elif not diagnostics.BSP %}
+                    <td class="text-right">API Not Available</td>
                   {% else %}
                     <td class="text-right">{{ '%0.2f' % diagnostics.BSP|float }}%</td>
                   {% endif %}

--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -46,9 +46,9 @@
                 </tr>
                 <tr>
                   <td>Sync Percentage</td>
-                  {% if diagnostics.BSP > 99.98 %}
+                  {% if diagnostics.BSP and diagnostics.BSP > 99.98 %}
                     <td class="text-right">100%</td>
-                  {% elif diagnostics.BSP == -100.00 %}
+                  {% elif diagnostics.BSP and diagnostics.BSP == -100.00 %}
                     <td class="text-right">Not Available</td>
                   {% elif not diagnostics.BSP %}
                     <td class="text-right">API Not Available</td>

--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -48,7 +48,7 @@
                   <td>Sync Percentage</td>
                   {% if diagnostics.BSP > 99.98 %}
                     <td class="text-right">100%</td>
-                  {% elif diagnostics.BSP == -100.00 %}
+                  {% elif diagnostics.BSP < 0 %}
                     <td class="text-right">Not Available</td>
                   {% else %}
                     <td class="text-right">{{ '%0.2f' % diagnostics.BSP|float }}%</td>

--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -47,7 +47,7 @@
                 <tr>
                   <td>Sync Percentage</td>
                   {% if not diagnostics.BSP %}
-                    <td class="text-right">API Not Available</td>
+                    <td class="text-right">Helium API Not Available</td>
                   {% elif diagnostics.BSP > 99.98 %}
                     <td class="text-right">100%</td>
                   {% elif diagnostics.BSP == -100.00 %}
@@ -58,10 +58,10 @@
                 </tr>
                 <tr>
                   <td>Height Status</td>
-                  {% if diagnostics.MH == -1 %}
+                  {% if not diagnostics.MH %}
                     <td class="text-right">Not Available</td>
                   {% elif not diagnostics.BCH %}
-                    <td class="text-right">API Not Available</td>
+                    <td class="text-right">Helium API Not Available</td>
                   {% else %}
                     <td class="text-right">{{ diagnostics.MH }} / {{ diagnostics.BCH }}</td>
                   {% endif %}

--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -46,12 +46,12 @@
                 </tr>
                 <tr>
                   <td>Sync Percentage</td>
-                  {% if diagnostics.BSP and diagnostics.BSP > 99.98 %}
-                    <td class="text-right">100%</td>
-                  {% elif diagnostics.BSP and diagnostics.BSP == -100.00 %}
-                    <td class="text-right">Not Available</td>
-                  {% elif not diagnostics.BSP %}
+                  {% if not diagnostics.BSP %}
                     <td class="text-right">API Not Available</td>
+                  {% elif diagnostics.BSP > 99.98 %}
+                    <td class="text-right">100%</td>
+                  {% elif diagnostics.BSP == -100.00 %}
+                    <td class="text-right">Not Available</td>
                   {% else %}
                     <td class="text-right">{{ '%0.2f' % diagnostics.BSP|float }}%</td>
                   {% endif %}
@@ -60,6 +60,8 @@
                   <td>Height Status</td>
                   {% if diagnostics.MH == -1 %}
                     <td class="text-right">Not Available</td>
+                  {% elif not diagnostics.BCH %}
+                    <td class="text-right">API Not Available</td>
                   {% else %}
                     <td class="text-right">{{ diagnostics.MH }} / {{ diagnostics.BCH }}</td>
                   {% endif %}

--- a/hw_diag/tests/test_blockchain_helium_height.py
+++ b/hw_diag/tests/test_blockchain_helium_height.py
@@ -31,7 +31,7 @@ class TestHelium(unittest.TestCase):
     @patch('requests.get', return_value=the_response2)
     def test_unsuccessful_request(self, _):
         res = get_helium_blockchain_height()
-        self.assertEqual(res, None)
+        self.assertEqual(res, -1)
 
     data = """{
          }"""

--- a/hw_diag/tests/test_blockchain_helium_height.py
+++ b/hw_diag/tests/test_blockchain_helium_height.py
@@ -31,7 +31,7 @@ class TestHelium(unittest.TestCase):
     @patch('requests.get', return_value=the_response2)
     def test_unsuccessful_request(self, _):
         res = get_helium_blockchain_height()
-        self.assertEqual(res, -1)
+        self.assertEqual(res, None)
 
     data = """{
          }"""

--- a/hw_diag/utilities/blockchain.py
+++ b/hw_diag/utilities/blockchain.py
@@ -1,6 +1,11 @@
 import requests
 import os
 
+HELIUM_MINER_HEIGHT_URL = os.getenv(
+    'HELIUM_MINER_HEIGHT_URL',
+    'https://api.helium.io/v1/blocks/height'
+)
+
 
 def get_helium_blockchain_height():
     """
@@ -10,7 +15,7 @@ def get_helium_blockchain_height():
     Possible exceptions:
     TypeError - if the key ['data']['height'] in response is not found.
     """
-    result = requests.get('https://api.helium.io/v1/blocks/height',
+    result = requests.get(HELIUM_MINER_HEIGHT_URL,
                           timeout=os.getenv('HELIUM_API_TIMEOUT_SECONDS', 5))
     if result.status_code == 200:
         result = result.json()
@@ -23,4 +28,4 @@ def get_helium_blockchain_height():
         return result
     else:
         print("Request failed %s" % result)
-        return -1
+        return None

--- a/hw_diag/utilities/blockchain.py
+++ b/hw_diag/utilities/blockchain.py
@@ -21,3 +21,6 @@ def get_helium_blockchain_height():
                 "Not found value from key ['data']['height'] in json"
             )
         return result
+    else:
+        print("Request failed %s" % result)
+        return -1

--- a/hw_diag/utilities/miner.py
+++ b/hw_diag/utilities/miner.py
@@ -14,7 +14,7 @@ def fetch_miner_data(diagnostics):
         LOGGER.exception(err)
         diagnostics['MC'] = "Failed to Fetch"
         diagnostics['MD'] = "Failed to Fetch"
-        diagnostics['MH'] = -1
+        diagnostics['MH'] = None
         diagnostics['MN'] = "Failed to Fetch"
         diagnostics['MR'] = "Failed to Fetch"
         return diagnostics
@@ -22,7 +22,7 @@ def fetch_miner_data(diagnostics):
         LOGGER.exception(err)
         diagnostics['MC'] = "Failed to Fetch"
         diagnostics['MD'] = "Failed to Fetch"
-        diagnostics['MH'] = -1
+        diagnostics['MH'] = None
         diagnostics['MN'] = "Failed to Fetch"
         diagnostics['MR'] = "Failed to Fetch"
         return diagnostics


### PR DESCRIPTION
**Why**
Diagnostics fail entirely if unable to get Helium blockchain height.

**How**
Return -1 if request fails.
It's not clear why the request is failing in the first place.
curl to the same endpoint works from miners that are actively failing.
Tried disabling cache on the request, but no impact.

**References**
Related to: https://github.com/NebraLtd/hm-diag/issues/223