### PR TITLE
fix: LOR should be a factor for PF

### DIFF
--- a/hw_diag/diagnostics/pf_diagnostic.py
+++ b/hw_diag/diagnostics/pf_diagnostic.py
@@ -2,7 +2,7 @@ from hm_pyhelper.diagnostics.diagnostic import Diagnostic
 
 KEY = 'PF'
 FRIENDLY_NAME = "legacy_pass_fail"
-CHECK_KEYS = ["ECC", "E0", "BT"]
+CHECK_KEYS = ["ECC", "E0", "BT", "LOR"]
 
 
 class PfDiagnostic(Diagnostic):

--- a/hw_diag/tests/diagnostics/test_pf_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_pf_diagnostic.py
@@ -20,6 +20,7 @@ class TestPfDiagnostic(unittest.TestCase):
             'legacy_pass_fail': True,
             'BT': True,
             'E0': True,
+            'LOR': True,
             'ECC': True,
             'PF': True,
         })


### PR DESCRIPTION
**Why**
We want to ignore W0 and only consider LOR, BT, E0, and ECC for determining PF.

**How**
Partial revert of: https://github.com/NebraLtd/hm-diag/pull/221/commits/205515f9a5e6aee6954e2f7ab11227b4305f2f17

**References**
- Related to: https://github.com/NebraLtd/hm-diag/issues/222