### PR TITLE
fix: Helium API not returning

### DIFF
--- a/hw_diag/utilities/blockchain.py
+++ b/hw_diag/utilities/blockchain.py
@@ -16,9 +16,10 @@ def get_helium_blockchain_height():
     TypeError - if the key ['data']['height'] in response is not found.
     """
     headers = {
-                ("user-agent': 'Mozilla/5.0 (X11; U;"
-                 " Linux i686; it; rv:1.9.0.10)"
-                 " Gecko/2009042513 Ubuntu/8.04 (hardy) Firefox/3.0.10"),
+                "user-agent": ("Mozilla/5.0 (X11; U;"
+                               " Linux i686; it; rv:1.9.0.10)"
+                               " Gecko/2009042513 Ubuntu/8.04"
+                               " (hardy) Firefox/3.0.10"),
               }
     result = requests.get(HELIUM_MINER_HEIGHT_URL,
                           headers=headers,

--- a/hw_diag/utilities/blockchain.py
+++ b/hw_diag/utilities/blockchain.py
@@ -16,8 +16,9 @@ def get_helium_blockchain_height():
     TypeError - if the key ['data']['height'] in response is not found.
     """
     headers = {
-                'user-agent': 'Mozilla/5.0 (X11; U; Linux i686; it; rv:1.9.0.10)'%
-                ' Gecko/2009042513 Ubuntu/8.04 (hardy) Firefox/3.0.10',
+                ("user-agent': 'Mozilla/5.0 (X11; U;"
+                 " Linux i686; it; rv:1.9.0.10)"
+                 " Gecko/2009042513 Ubuntu/8.04 (hardy) Firefox/3.0.10"),
               }
     result = requests.get(HELIUM_MINER_HEIGHT_URL,
                           headers=headers,

--- a/hw_diag/utilities/blockchain.py
+++ b/hw_diag/utilities/blockchain.py
@@ -15,7 +15,12 @@ def get_helium_blockchain_height():
     Possible exceptions:
     TypeError - if the key ['data']['height'] in response is not found.
     """
+    headers = {
+                'user-agent': 'Mozilla/5.0 (X11; U; Linux i686; it; rv:1.9.0.10)'%
+                ' Gecko/2009042513 Ubuntu/8.04 (hardy) Firefox/3.0.10',
+              }
     result = requests.get(HELIUM_MINER_HEIGHT_URL,
+                          headers=headers,
                           timeout=os.getenv('HELIUM_API_TIMEOUT_SECONDS', 5))
     if result.status_code == 200:
         result = result.json()

--- a/hw_diag/utilities/blockchain.py
+++ b/hw_diag/utilities/blockchain.py
@@ -16,10 +16,10 @@ def get_helium_blockchain_height():
     TypeError - if the key ['data']['height'] in response is not found.
     """
     headers = {
-                "user-agent": ("Mozilla/5.0 (X11; U;"
-                               " Linux i686; it; rv:1.9.0.10)"
-                               " Gecko/2009042513 Ubuntu/8.04"
-                               " (hardy) Firefox/3.0.10"),
+                "user-agent": ("Mozilla/5.0"
+                               " (Macintosh; Intel Mac OS X 10_15_6)"
+                               " AppleWebKit/605.1.15 (KHTML, like Gecko)"
+                               " Version/14.1.1 Safari/605.1.15"),
               }
     result = requests.get(HELIUM_MINER_HEIGHT_URL,
                           headers=headers,


### PR DESCRIPTION
**Why**
Helium API was not returning values because of missing headers 

**How**
Added headers specifying the user-agent field and it returned perfectly. Helium API is now happy with our request and returning a proper response

**References**
Closes: #232 