### PR TITLE
Fix slow responses issue by switching to port 7000

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ RUN \
     python3 setup.py install && \
     rm -rf /tmp/build
 
-ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:5000", "hw_diag:wsgi_app"]
+ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:7000", "hw_diag:wsgi_app"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - 'pktfwdr:/var/pktfwd'
       - 'miner-storage:/var/data'
     ports:
-      - '80:5000'
+      - '80:7000'
     cap_add:
       - SYS_RAWIO
     devices:

--- a/hw_diag/tests/diagnostics/test_version_endpoint.py
+++ b/hw_diag/tests/diagnostics/test_version_endpoint.py
@@ -1,0 +1,85 @@
+import unittest
+from unittest.mock import patch, mock_open
+from hm_pyhelper.diagnostics.diagnostics_report import \
+    DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+
+from hw_diag.diagnostics.mac_diagnostics import MacDiagnostic, MacDiagnostics
+
+
+class TestMacDiagnostics(unittest.TestCase):
+    @patch("hw_diag.diagnostics.mac_diagnostics.get_mac_address",
+           return_value='foo')
+    def test_success(self, mock):
+        diagnostic = MacDiagnostic('I0', 'friendly', '/')
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'I0': 'foo',
+            'friendly': 'foo'
+        })
+
+    @patch("hw_diag.diagnostics.mac_diagnostics.get_mac_address",
+           new_callable=mock_open)
+    def test_error(self, mock):
+        mock.side_effect = Exception('No file')
+        diagnostic = MacDiagnostic('I0', 'friendly', '/')
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['I0'],
+            'I0': 'No file',
+            'friendly': 'No file'
+        })
+
+    @patch("hw_diag.diagnostics.mac_diagnostics.get_mac_address",
+           return_value='foo')
+    def test_macs_success(self, mock):
+        diagnostic = MacDiagnostics()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'E0': 'foo',
+            'eth_mac_address': 'foo',
+            'W0': 'foo',
+            'wifi_mac_address': 'foo'
+        })
+
+    @patch("hw_diag.diagnostics.mac_diagnostics.get_mac_address",
+           side_effect=FileNotFoundError("File Not Found Error"))
+    def test_macs_file_exception(self, mock):
+        diagnostic = MacDiagnostics()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['E0', 'W0'],
+            'E0': 'File Not Found Error',
+            'eth_mac_address': 'File Not Found Error',
+            'W0': 'File Not Found Error',
+            'wifi_mac_address': 'File Not Found Error'
+        })
+
+    @patch("hw_diag.diagnostics.mac_diagnostics.get_mac_address",
+           side_effect=PermissionError("Permission Error"))
+    def test_macs_permission_exception(self, mock):
+        diagnostic = MacDiagnostics()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['E0', 'W0'],
+            'E0': 'Permission Error',
+            'eth_mac_address': 'Permission Error',
+            'W0': 'Permission Error',
+            'wifi_mac_address': 'Permission Error'
+        })

--- a/hw_diag/tests/test_views_diagnostics.py
+++ b/hw_diag/tests/test_views_diagnostics.py
@@ -1,7 +1,7 @@
 import unittest
 import flask
 from unittest.mock import patch, mock_open
-
+import os
 
 # Test cases
 from hw_diag.app import get_app
@@ -68,3 +68,13 @@ class TestGetDiagnostics(unittest.TestCase):
             self.assertIsInstance(resp, flask.Response)
             self.assertEqual(resp.status_code, 200)
             self.assertEqual(resp.status, '200 OK')
+
+    @patch.dict(os.environ, {'FIRMWARE_VERSION': '1337.13.37', 'DIAGNOSTICS_VERSION': 'aabbffe'})
+    def test_version_endpoint(self):
+        # Check the version json output
+        resp = self.client.get('/version')
+        reply = resp.json
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(reply['firmware_version'], '1337.13.37')
+        self.assertEqual(reply['diagnostics_version'], 'aabbffe')

--- a/hw_diag/tests/test_views_diagnostics.py
+++ b/hw_diag/tests/test_views_diagnostics.py
@@ -69,7 +69,10 @@ class TestGetDiagnostics(unittest.TestCase):
             self.assertEqual(resp.status_code, 200)
             self.assertEqual(resp.status, '200 OK')
 
-    @patch.dict(os.environ, {'FIRMWARE_VERSION': '1337.13.37', 'DIAGNOSTICS_VERSION': 'aabbffe'})
+    @patch.dict(
+        os.environ,
+        {'FIRMWARE_VERSION': '1337.13.37', 'DIAGNOSTICS_VERSION': 'aabbffe'}
+    )
     def test_version_endpoint(self):
         # Check the version json output
         resp = self.client.get('/version')

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -101,7 +101,7 @@ def get_initialisation_file():
 def version_information():
     response = {
         'firmware_version': os.getenv('FIRMWARE_VERSION', 'unknown'),
-        'diagnostics_version': 'unknown'
+        'diagnostics_version': os.getenv('DIAGNOSTICS_VERSION', 'unknown'),
     }
 
     return response

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -94,3 +94,9 @@ def get_initialisation_file():
     diagnostics_str = str(json.dumps(diagnostics_report))
     response_b64 = base64.b64encode(diagnostics_str.encode('ascii'))
     return response_b64
+
+
+@DIAGNOSTICS.route('/version')
+def version_information():
+    response = {'miner_version': 'unknown', 'diagnostics_version': 'unknown'}
+    return response

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -98,5 +98,9 @@ def get_initialisation_file():
 
 @DIAGNOSTICS.route('/version')
 def version_information():
-    response = {'miner_version': 'unknown', 'diagnostics_version': 'unknown'}
+    response = {
+        'firmware_version': os.getenv('FIRMWARE_VERSION', 'unknown'),
+        'diagnostics_version': 'unknown'
+    }
+
     return response

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -97,6 +97,7 @@ def get_initialisation_file():
 
 
 @DIAGNOSTICS.route('/version')
+@cache.cached(timeout=60)
 def version_information():
     response = {
         'firmware_version': os.getenv('FIRMWARE_VERSION', 'unknown'),


### PR DESCRIPTION
See the original discussion in #248 .

Basically using a different port instead of the current 5000  for gunicorn solves the issue.

Merging of this PR should be done in parallel with:  https://github.com/NebraLtd/helium-miner-software/pull/276
