### PR TITLE
fix: strip \x00 from serial number

### DIFF
--- a/hw_diag/diagnostics/serial_number_diagnostic.py
+++ b/hw_diag/diagnostics/serial_number_diagnostic.py
@@ -13,7 +13,7 @@ class SerialNumberDiagnostic(Diagnostic):
 
     def perform_test(self, diagnostics_report):
         try:
-            serial_number = open(SERIAL_FILEPATH).readline()
+            serial_number = open(SERIAL_FILEPATH).readline().rstrip('\x00')
             diagnostics_report.record_result(serial_number, self)
 
         except FileNotFoundError as e:

--- a/hw_diag/tests/diagnostics/test_serial_number_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_serial_number_diagnostic.py
@@ -6,12 +6,26 @@ from hm_pyhelper.diagnostics.diagnostics_report import \
 from hw_diag.diagnostics.serial_number_diagnostic import SerialNumberDiagnostic
 
 VALID_CPU_PROC = """00000000ddd1a4c2"""
+PADDED_CPU_PROC = "%s\x00" % VALID_CPU_PROC
 
 
 class TestSerialNumberDiagnostic(unittest.TestCase):
 
     @patch("builtins.open", new_callable=mock_open, read_data=VALID_CPU_PROC)
     def test_success(self, mock):
+        diagnostic = SerialNumberDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'serial_number': '00000000ddd1a4c2',
+            'serial_number': '00000000ddd1a4c2'
+        })
+
+    @patch("builtins.open", new_callable=mock_open, read_data=PADDED_CPU_PROC)
+    def test_success_strip(self, mock):
         diagnostic = SerialNumberDiagnostic()
         diagnostics_report = DiagnosticsReport([diagnostic])
         diagnostics_report.perform_diagnostics()

--- a/hw_diag/tests/test_get_serial_number.py
+++ b/hw_diag/tests/test_get_serial_number.py
@@ -5,15 +5,22 @@ sys.path.append("..")
 from hw_diag.utilities.hardware import get_serial_number  # noqa
 
 
-class TestGetPublicKeys(unittest.TestCase):
+class TestGetSerialNumber(unittest.TestCase):
 
-    TEST_DATA = """00000000a3e7kg80"""
+    TEST_DATA = "00000000a3e7kg80"
 
     right_value = {'serial_number': '00000000a3e7kg80'}
     diag = {}
 
     def test_get_serialnumber(self):
-        m = mock_open(read_data=''.join(self.TEST_DATA))
+        m = mock_open(read_data=self.TEST_DATA)
+        with patch('builtins.open', m):
+            get_serial_number(self.diag)
+            self.assertEqual(self.diag["serial_number"],
+                             self.right_value["serial_number"])
+
+    def test_strip_serialnumber(self):
+        m = mock_open(read_data="%s\x00" % self.TEST_DATA)
         with patch('builtins.open', m):
             get_serial_number(self.diag)
             self.assertEqual(self.diag["serial_number"],

--- a/hw_diag/utilities/hardware.py
+++ b/hw_diag/utilities/hardware.py
@@ -71,7 +71,8 @@ def get_serial_number(diagnostics):
     Writes the received value to the dictionary
     """
     try:
-        serial_number = open("/proc/device-tree/serial-number").readline()
+        serial_number = open("/proc/device-tree/serial-number").readline() \
+                            .rstrip('\x00')
     except FileNotFoundError as e:
         raise e
     except PermissionError as e:


### PR DESCRIPTION
**Why**
As a hotspot owner, I want a predictable serial number so that I can onboard.

**How**
Null characters from reading serial number file should not be considered part of serial number.

**References**

- Fixes: Convert RPI to Serial Number hm-diag#219