### PR TITLE
Handle gateway mfr exit code exception

### DIFF
--- a/hw_diag/app.py
+++ b/hw_diag/app.py
@@ -26,8 +26,12 @@ def perform_key_provisioning():
 
 
 def get_app(name):
-    if os.getenv('BALENA_DEVICE_TYPE', False):
-        perform_key_provisioning()
+    try:
+        if os.getenv('BALENA_DEVICE_TYPE', False):
+            perform_key_provisioning()
+    except Exception as e:
+        log.error('Failed to provision key: {}'
+                  .format(e))
 
     app = Flask(name)
 

--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -28,7 +28,13 @@
         <div class="text-center pb-4 mb-4 border-bottom border-light">
             <h1>Diagnostics Information</h1>
             <br />
-            <h3>{{ diagnostics.AN }}</h3>
+            <h3>
+              {% if diagnostics.AN == "ECC failure" %}
+                Animal Name Unavailable
+              {% else %}
+                {{ diagnostics.AN }}
+              {% endif %}
+            </h3>
             {% if diagnostics.PF %}
                     <h3 class="text-success">All Ok</h3>
             {% else %}
@@ -41,8 +47,13 @@
             <div class="card mb-0 h-100">
               <table class="table dt-responsive nowrap m-2 w-auto">
                 <tr>
-                  <td class="border-0">Helium Address</td>
-                  <td class="border-0 text-right"><a href="https://explorer.helium.com/hotspots/{{ diagnostics.PK }}" target="_blank">View on Explorer</a></td>
+                  {% if diagnositcs.PK == "ECC failure" %}
+                    <td class="border-0">Helium Address</td>
+                    <td class="border-0 text-right"><a href="https://explorer.helium.com/hotspots/{{ diagnostics.PK }}" target="_blank">View on Explorer</a></td>
+                  {% else %}
+                    <td class="border-0">Helium Address</td>
+                    <td class="border-0 text-right">Animal Name Unavailable</td>
+                  {% endif %}
                 </tr>
                 <tr>
                   <td>Sync Percentage</td>

--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -29,7 +29,7 @@
             <h1>Diagnostics Information</h1>
             <br />
             <h3>
-              {% if diagnostics.AN == "ECC failure" %}
+              {% if not diagnostics.AN %}
                 Animal Name Unavailable
               {% else %}
                 {{ diagnostics.AN }}

--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -47,7 +47,7 @@
             <div class="card mb-0 h-100">
               <table class="table dt-responsive nowrap m-2 w-auto">
                 <tr>
-                  {% if diagnositcs.PK == "ECC failure" %}
+                  {% if diagnositcs.PK != "ECC failure" %}
                     <td class="border-0">Helium Address</td>
                     <td class="border-0 text-right"><a href="https://explorer.helium.com/hotspots/{{ diagnostics.PK }}" target="_blank">View on Explorer</a></td>
                   {% else %}

--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -47,12 +47,12 @@
             <div class="card mb-0 h-100">
               <table class="table dt-responsive nowrap m-2 w-auto">
                 <tr>
-                  {% if diagnositcs.PK != "ECC failure" %}
-                    <td class="border-0">Helium Address</td>
-                    <td class="border-0 text-right"><a href="https://explorer.helium.com/hotspots/{{ diagnostics.PK }}" target="_blank">View on Explorer</a></td>
-                  {% else %}
+                  {% if not diagnostics.PK %}
                     <td class="border-0">Helium Address</td>
                     <td class="border-0 text-right">Animal Name Unavailable</td>
+                  {% else %}
+                    <td class="border-0">Helium Address</td>
+                    <td class="border-0 text-right"><a href="https://explorer.helium.com/hotspots/{{ diagnostics.PK }}" target="_blank">View on Explorer</a></td>
                   {% endif %}
                 </tr>
                 <tr>

--- a/hw_diag/tests/test_app.py
+++ b/hw_diag/tests/test_app.py
@@ -1,6 +1,8 @@
 import unittest
+import os
 from flask import Flask
 from unittest.mock import patch
+from hm_pyhelper.exceptions import ECCMalfunctionException
 
 
 # Test cases
@@ -12,6 +14,18 @@ class TestGetApp(unittest.TestCase):
 
     def test_returns_flask_app(self):
         # Check a flask app is returned by get_app.
+        app = get_app(__name__)
+        self.assertIsInstance(app, Flask)
+
+    @patch('hw_diag.app.perform_key_provisioning')
+    @patch.dict(os.environ, {"BALENA_DEVICE_TYPE": "False"})
+    def test_returns_flask_app_with_gateway_exception(
+                                                      self,
+                                                      mock_provision):
+        mock_provision.side_effect = ECCMalfunctionException(
+                                                             "Gateway exited"
+                                                             " with non-zero"
+                                                             " code")
         app = get_app(__name__)
         self.assertIsInstance(app, Flask)
 

--- a/hw_diag/tests/test_hardware.py
+++ b/hw_diag/tests/test_hardware.py
@@ -24,8 +24,8 @@ class TestHardware(unittest.TestCase):
         mocked_get_public_keys_rust.return_value = False
         keys = get_public_keys_and_ignore_errors()
 
-        self.assertEqual(keys['key'], 'ECC failure')
-        self.assertEqual(keys['name'], 'ECC failure')
+        self.assertIsNone(keys['key'])
+        self.assertIsNone(keys['name'])
 
     @patch('dbus.SystemBus')
     @patch('dbus.Interface')

--- a/hw_diag/utilities/hardware.py
+++ b/hw_diag/utilities/hardware.py
@@ -250,9 +250,16 @@ def lora_module_test():
 
 
 def get_public_keys_and_ignore_errors():
-    public_keys = get_public_keys_rust()
-    if not public_keys:
-        error_msg = "ECC failure"
+    error_msg = "ECC failure"
+    try:
+        public_keys = get_public_keys_rust()
+        if not public_keys:
+            public_keys = {
+                'name': error_msg,
+                'key': error_msg
+            }
+    except Exception as e:
+        logging.error(e)
         public_keys = {
             'name': error_msg,
             'key': error_msg

--- a/hw_diag/utilities/hardware.py
+++ b/hw_diag/utilities/hardware.py
@@ -250,7 +250,7 @@ def lora_module_test():
 
 
 def get_public_keys_and_ignore_errors():
-    error_msg = "ECC failure"
+    error_msg = None
     try:
         public_keys = get_public_keys_rust()
         if not public_keys:

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ requests==2.26.0
 retry==0.9.2
 sentry-sdk==1.1.0
 dbus-python==1.2.16
-hm_pyhelper==0.12.0
+hm-pyhelper==0.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ gunicorn==20.1.0
 requests==2.26.0
 retry==0.9.2
 sentry-sdk==1.1.0
-hm-pyhelper==0.11.13
 dbus-python==1.2.16
+hm_pyhelper==0.12.0


### PR DESCRIPTION
**Issue**
- Link: https://github.com/NebraLtd/hm-diag/issues/239
- Summary: Gateway MFR Error causing diagnostics page to not open or create a boot loop on the container.

**How**
Traced back the exception and added handling to the source of the issue. This lets the diagnostics continue gracefully and not raise an exception but instead handle it and display the diagnostics page but with errors displayed on diag view. 

**Screenshots**
<img width="1152" alt="Screen Shot 2021-12-10 at 2 57 32 AM" src="https://user-images.githubusercontent.com/6146752/145571850-c911b405-28c1-484f-8418-99cdb24f0ad1.png">


**References**
The screenshot above is what the dashboard looks like with the error handling when ECC fails from the error "Gateway mfr exited with non-zero status"

How to recreate this error locally:
In Balena dashboard set i2c_arm to false and as a result this will trigger the ECC to fail as the bus is inactive. Previously this triggered a boot loop on the diagnostics container, now it handles the error and displays it on the diagnostics page.

**Checklist**

- [x] Tests added
- [ ] Cleaned up commit history (rebase!)
- [x] Documentation added
- [x] Thought about variable and method names

