### PR TITLE
Adds wget for healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ ENV PYTHON_DEPENDENCIES_DIR=/opt/python-dependencies
 
 RUN \
     install_packages \
+        wget \
         i2c-tools \
         libdbus-1-3
 


### PR DESCRIPTION
**Issue**
Closes https://github.com/NebraLtd/hm-diag/issues/273


**How**
In theory, the [healthcheck](https://github.com/NebraLtd/hm-diag/blob/master/Dockerfile#L35-L40) shouldn't really do anything on Balena, since it hasn't been fully implemented. However, as part of the logs in [273](https://github.com/NebraLtd/hm-diag/issues/273) it does indeed seems like they now have been. 

It's still clear if these healthchecks actually do anything, but at least it shouldn't cause any harm to resolve this.
