### PR TITLE
Update Copyright Year to 2022

### DIFF
--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -190,7 +190,7 @@
       {% endif %}
       <p>To get support please visit <a href="https://nebra.io/helium-support">https://nebra.io/helium-support</a></p>
       <p><a href="/json">Download Diagnostics Info for Support</a></p>
-      <p>&copy; Nebra LTD. 2020-2022<p>
+      <p>&copy; Nebra LTD. 2020-{% now "Y" %}<p>
     </div>
   </section>
 </body>

--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -190,7 +190,7 @@
       {% endif %}
       <p>To get support please visit <a href="https://nebra.io/helium-support">https://nebra.io/helium-support</a></p>
       <p><a href="/json">Download Diagnostics Info for Support</a></p>
-      <p>&copy; Nebra LTD. 2020-2021<p>
+      <p>&copy; Nebra LTD. 2020-2022<p>
     </div>
   </section>
 </body>


### PR DESCRIPTION
**Issue**

- Link: N/A
- Summary: Change the copyright year range on the diagnostic page from "2020-2021" to "2020-2022".

**How**
- Change 2021 to 2022 in the copyright notice on the bottom of the diag page.

**Screenshots**
Old:
![image](https://user-images.githubusercontent.com/8300089/148308112-5c04f923-4a55-4d63-b997-a74c4f140f58.png)

New:
![image](https://user-images.githubusercontent.com/8300089/148308165-284dcfb1-4309-4494-8c21-b5068d5dea91.png)

**References**
N/A

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

