### PR TITLE
fix: remove wget as it's now not used anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,11 +29,10 @@ ENV PYTHON_DEPENDENCIES_DIR=/opt/python-dependencies
 
 RUN \
     install_packages \
-        wget \
         i2c-tools \
         libdbus-1-3
 
-# @TODO: Re-enable health-check once Balena supports it fully.
+# @TODO: Re-enable health-check (and add wget install) once Balena supports it fully.
 # HEALTHCHECK \
 #    --interval=120s \
 #    --timeout=5s \


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-diag/commit/ccaa8e4c57d6b6681efc21f90c7747d6988ab795
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Healthcheck not fully supported by balena yet so we don't need wget at the moment in container

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

https://github.com/NebraLtd/hm-diag/commit/ccaa8e4c57d6b6681efc21f90c7747d6988ab795

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [x] Documentation added
- [x] Thought about variable and method names

