### PR TITLE
Bump hm_pyhelper version 0.12.2 -> 0.13.1

### DIFF
--- a/hw_diag/tests/diagnostics/test_bt_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_bt_diagnostic.py
@@ -78,7 +78,7 @@ class TestBtDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['BT'],
+            DIAGNOSTICS_ERRORS_KEY: ['BT', 'bluetooth'],
             'BT': 'Bluez is working but, no Bluetooth devices detected.',
             'bluetooth': 'Bluez is working but, no Bluetooth devices detected.'
         })
@@ -99,7 +99,7 @@ class TestBtDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['BT'],
+            DIAGNOSTICS_ERRORS_KEY: ['BT', 'bluetooth'],
             'BT': 'Not authorized',
             'bluetooth': 'Not authorized'
         })

--- a/hw_diag/tests/diagnostics/test_ecc_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_ecc_diagnostic.py
@@ -34,7 +34,7 @@ class TestECCDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['ECC'],
+            DIAGNOSTICS_ERRORS_KEY: ['ECC', 'ECC'],
             'ECC': 'gateway_mfr test finished with error, {"result": "fail"}'
         })
 
@@ -48,7 +48,7 @@ class TestECCDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['ECC'],
+            DIAGNOSTICS_ERRORS_KEY: ['ECC', 'ECC'],
             'ECC': 'ECC Malfunctioned'
         })
 
@@ -63,7 +63,7 @@ class TestECCDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['ECC'],
+            DIAGNOSTICS_ERRORS_KEY: ['ECC', 'ECC'],
             'ECC': 'Gateway MFR File Not Found'
         })
 
@@ -77,6 +77,6 @@ class TestECCDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['ECC'],
+            DIAGNOSTICS_ERRORS_KEY: ['ECC', 'ECC'],
             'ECC': 'Resource Busy Error'
         })

--- a/hw_diag/tests/diagnostics/test_env_var_diagnostics.py
+++ b/hw_diag/tests/diagnostics/test_env_var_diagnostics.py
@@ -29,7 +29,7 @@ class TestEnvVarDiagnostics(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['DIAGNOSTIC_KEY'],
+            DIAGNOSTICS_ERRORS_KEY: ['DIAGNOSTIC_KEY', 'ENV_VAR'],
             'DIAGNOSTIC_KEY': 'Env var ENV_VAR not set',
             'ENV_VAR': 'Env var ENV_VAR not set'
         })

--- a/hw_diag/tests/diagnostics/test_key_diagnostics.py
+++ b/hw_diag/tests/diagnostics/test_key_diagnostics.py
@@ -35,7 +35,7 @@ class TestKeyDiagnostics(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['KK'],
+            DIAGNOSTICS_ERRORS_KEY: ['KK', 'test_key'],
             'KK': 'Key key_location not found',
             'test_key': 'Key key_location not found'
         })

--- a/hw_diag/tests/diagnostics/test_lora_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_lora_diagnostic.py
@@ -32,7 +32,7 @@ class TestLoraDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['LOR'],
+            DIAGNOSTICS_ERRORS_KEY: ['LOR', 'lora'],
             'LOR': False,
             'lora': False
         })

--- a/hw_diag/tests/diagnostics/test_lte_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_lte_diagnostic.py
@@ -63,7 +63,7 @@ class TestLteDiagnostics(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['LTE'],
+            DIAGNOSTICS_ERRORS_KEY: ['LTE', 'lte'],
             'LTE': 'ModemManager is working but, no LTE devices detected.',
             'lte': 'ModemManager is working but, no LTE devices detected.'
         })
@@ -84,7 +84,7 @@ class TestLteDiagnostics(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['LTE'],
+            DIAGNOSTICS_ERRORS_KEY: ['LTE', 'lte'],
             'LTE': 'Not authorized',
             'lte': 'Not authorized'
         })

--- a/hw_diag/tests/diagnostics/test_mac_diagnostics.py
+++ b/hw_diag/tests/diagnostics/test_mac_diagnostics.py
@@ -31,7 +31,7 @@ class TestMacDiagnostics(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['I0'],
+            DIAGNOSTICS_ERRORS_KEY: ['I0', 'friendly'],
             'I0': 'No file',
             'friendly': 'No file'
         })
@@ -61,7 +61,8 @@ class TestMacDiagnostics(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['E0', 'W0'],
+            DIAGNOSTICS_ERRORS_KEY:
+                ['E0', 'eth_mac_address', 'W0', 'wifi_mac_address'],
             'E0': 'File Not Found Error',
             'eth_mac_address': 'File Not Found Error',
             'W0': 'File Not Found Error',
@@ -77,7 +78,8 @@ class TestMacDiagnostics(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['E0', 'W0'],
+            DIAGNOSTICS_ERRORS_KEY:
+                ['E0', 'eth_mac_address', 'W0', 'wifi_mac_address'],
             'E0': 'Permission Error',
             'eth_mac_address': 'Permission Error',
             'W0': 'Permission Error',

--- a/hw_diag/tests/diagnostics/test_pf_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_pf_diagnostic.py
@@ -32,7 +32,7 @@ class TestPfDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['PF'],
+            DIAGNOSTICS_ERRORS_KEY: ['PF', 'legacy_pass_fail'],
             'PF': False,
             'legacy_pass_fail': False,
         })

--- a/hw_diag/tests/diagnostics/test_serial_number_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_serial_number_diagnostic.py
@@ -46,7 +46,7 @@ class TestSerialNumberDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['serial_number'],
+            DIAGNOSTICS_ERRORS_KEY: ['serial_number', 'serial_number'],
             'serial_number': 'File not found',
             'serial_number': 'File not found'
         })
@@ -60,7 +60,7 @@ class TestSerialNumberDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['serial_number'],
+            DIAGNOSTICS_ERRORS_KEY: ['serial_number', 'serial_number'],
             'serial_number': 'Bad permissions',
             'serial_number': 'Bad permissions'
         })

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ requests==2.26.0
 retry==0.9.2
 sentry-sdk[Flask]==1.5.1
 dbus-python==1.2.16
-hm-pyhelper==0.13.1
+hm-pyhelper==0.13.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ requests==2.26.0
 retry==0.9.2
 sentry-sdk[Flask]==1.5.1
 dbus-python==1.2.16
-hm-pyhelper==0.12.2
+hm-pyhelper==0.13.1


### PR DESCRIPTION
**Issue**
Related by [#87](https://github.com/NebraLtd/hm-pyhelper/pull/87#pullrequestreview-840567508)

**How**
Update hm_pyhelper version. Fix unittests.

**Checklist**
- [x] Tests added
- [x] Cleaned up commit history (rebase!)

