### PR TITLE
feat: Added short Git hash report (hm-diag#205)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,3 +137,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# VSCode editor related stuff
+.vscode/

--- a/hw_diag/diagnostics/env_var_diagnostics.py
+++ b/hw_diag/diagnostics/env_var_diagnostics.py
@@ -19,6 +19,9 @@ ENV_VARS_MAPPING = [{
 }, {
     'ENV_VAR': 'VARIANT',
     'DIAGNOSTIC_KEY': 'VA'
+}, {
+    'ENV_VAR': 'FIRMWARE_SHORT_HASH',
+    'DIAGNOSTIC_KEY': 'firmware_short_hash'
 }]
 
 

--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -83,7 +83,7 @@
                 </tr>
                 <tr>
                   <td>Firmware Version</td>
-                  <td class="text-right">{{ diagnostics.FW }}</td>
+                  <td class="text-right">{{ diagnostics.FW }} ({{ diagnostics.firmware_short_hash }})</td>
                 </tr>
                 <tr>
                   <td>Frequency</td>

--- a/hw_diag/tests/diagnostics/test_env_var_diagnostics.py
+++ b/hw_diag/tests/diagnostics/test_env_var_diagnostics.py
@@ -56,5 +56,10 @@ class TestEnvVarDiagnostics(unittest.TestCase):
             'FIRMWARE_VERSION': 'foo',
             'FW': 'foo',
             'VARIANT': 'foo',
-            'VA': 'foo'
+            'VA': 'foo',
+            # We're moving towards longer lowercase key naming and will
+            # deprecate old ones in near future. Just keeping this entry in the
+            # list for the sake of style compatibility.
+            'FIRMWARE_SHORT_HASH': 'foo',
+            'firmware_short_hash': 'foo'
         })

--- a/hw_diag/tests/test_views_diagnostics.py
+++ b/hw_diag/tests/test_views_diagnostics.py
@@ -71,7 +71,11 @@ class TestGetDiagnostics(unittest.TestCase):
 
     @patch.dict(
         os.environ,
-        {'FIRMWARE_VERSION': '1337.13.37', 'DIAGNOSTICS_VERSION': 'aabbffe'}
+        {
+            'FIRMWARE_VERSION': '1337.13.37',
+            'DIAGNOSTICS_VERSION': 'aabbffe',
+            'FIRMWARE_SHORT_HASH': '0011223'
+        }
     )
     def test_version_endpoint(self):
         # Check the version json output
@@ -81,3 +85,4 @@ class TestGetDiagnostics(unittest.TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(reply['firmware_version'], '1337.13.37')
         self.assertEqual(reply['diagnostics_version'], 'aabbffe')
+        self.assertEqual(reply['firmware_short_hash'], '0011223')

--- a/hw_diag/utilities/shell.py
+++ b/hw_diag/utilities/shell.py
@@ -13,9 +13,10 @@ def get_environment_var(diagnostics):
         'BALENA_APP_NAME',
         'FREQ',
         'FIRMWARE_VERSION',
-        'VARIANT'
+        'VARIANT',
+        'FIRMWARE_SHORT_HASH'
     ]
-    keys = ["BN", "ID", "BA", "FR", "FW", "VA"]
+    keys = ["BN", "ID", "BA", "FR", "FW", "VA", "firmware_short_hash"]
 
     for (var, key) in zip(env_var, keys):
         diagnostics[key] = os.getenv(var)

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -107,6 +107,7 @@ def version_information():
     response = {
         'firmware_version': os.getenv('FIRMWARE_VERSION', 'unknown'),
         'diagnostics_version': os.getenv('DIAGNOSTICS_VERSION', 'unknown'),
+        'firmware_short_hash': os.getenv('FIRMWARE_SHORT_HASH', 'unknown'),
     }
 
     return response


### PR DESCRIPTION
Include short git-hash report.

- Link: hm-diag#205 
- Summary:

We needed to include short git hash of main repo (helium-miner-software) for release tracking purposes.

**How**
- The short git hash of main repo is fetched via an environment variable supplied by the main docker container composer (helium-miner-software)
- The hash is propagated via multiple routes (/json, /version, /)
- Short code for Short Git Hash (SGH) has been introduced.

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [x] Documentation added
- [x] Thought about variable and method names
