### PR TITLE
Support nebra.json and add_gateway_txn

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,68 @@ Find the IP address of the hotspot using Balena's dashboard or network scanner.
 The website is available on port `80` so you can simply input the hotspot's
 IP address in the browser.
 
-## Diagnostics JSON Layout
+## Diagnostics API
+
+This service exposes HTTP endpoints that provide diagnostics information about the miner.
+In the future, the pay load of all responses will be a [DiagnosticsReport](https://github.com/NebraLtd/hm-pyhelper/blob/ffeeb3b4e200e28f0887618b489411aea184072f/hm_pyhelper/diagnostics/diagnostics_report.py),
+but currently some endpoints still return regular JSON. The general format is:
+
+```
+{
+    'errors': ['key1', 'friendly_key1'],
+    'key1': 'Something went wrong',
+    'friendly_key1': 'Something went wrong',
+    'key2': True,
+    'friendly_key2': True
+}
+```
+
+Note that we are currently duplicating all values under both a 'key' and a 'friendly_key'. This is being
+done to enable us to slowly rename keys for human readability without risking breaking changes.
+
+HTTP error codes are used to communicate issues, when possible. However some endpoints (eg /json) return
+information about various parts of a miner. It is not obvious what subset of keys should be used for
+determining if the response is an error. In those cases, an HTTP code of 200 will be returned even though
+some errors may be present in the error array.
+
+### POST /v1/gen_add_gateway_txn
+
+#### Parameters
+None
+
+#### Response
+
+DiagnosticsReport containing key `destination_add_gateway_txn`. If valid, will be in the following format:
+
+
+
+### POST /v1/ack_add_gateway_txn
+
+### GET /initFile.txt
+
+#### Parameters
+None
+
+#### Response
+base64 encoded DiagnosticsReport.
+HTTP code always 200.
+
+### GET /version
+
+#### Parameters
+None
+
+#### Response
+Regular JSON, not a DiagnosticsReport.
+
+
+### GET /json
+
+#### Parameters
+None
+
+#### Response
+Currently returns regular JSON, not a DiagnosticsReport.
 
 As part of the code the system produces a JSON file which then is used to carry the data over easily to other parts of the system.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
     volumes:
       - 'pktfwdr:/var/pktfwd'
       - 'miner-storage:/var/data'
+      - 'nebra.json:/mnt/boot/nebra.json'
     ports:
       - '80:5000'
     cap_add:

--- a/hw_diag/diagnostics/add_gateway_txn/ack_add_gateway_txn_diagnostic.py
+++ b/hw_diag/diagnostics/add_gateway_txn/ack_add_gateway_txn_diagnostic.py
@@ -1,0 +1,29 @@
+from hm_pyhelper.constants.shipping import DESTINATION_WALLETS_KEY
+from hw_diag.utilities.hardware import remove_destination_wallets_from_nebra_json
+from .base_add_gateway_txn_diagnostic import BaseAddGatewayTxnDiagnostic
+
+
+class AckAddGatewayTxnDiagnostic(BaseAddGatewayTxnDiagnostic):
+    """
+    Removes DESTINATION_WALLETS_KEY from Nebra JSON if DESTINATION_NAME_KEY is present.
+    Records an error if DESTINATION_WALLETS_KEY is absent.
+    """
+    def __init__(self):
+        super(AckAddGatewayTxnDiagnostic, self). \
+            __init__(DESTINATION_WALLETS_KEY, DESTINATION_WALLETS_KEY)
+
+    def remove_destination_wallets(self) -> bool:
+        try:
+            remove_destination_wallets_from_nebra_json()
+            # Intentionally not recording a result, because we want the key to be omitted
+            return True
+        except Exception as e:
+            self.diagnostics_report.record_failure(e, self)
+            return False
+
+    def get_steps(self) -> list:
+        return [
+            self.load_and_validate_nebra_json,
+            self.load_and_validate_destination_wallets,
+            self.remove_destination_wallets,
+        ]

--- a/hw_diag/diagnostics/add_gateway_txn/base_add_gateway_txn_diagnostic.py
+++ b/hw_diag/diagnostics/add_gateway_txn/base_add_gateway_txn_diagnostic.py
@@ -1,0 +1,81 @@
+from hm_pyhelper.diagnostics import Diagnostic, DiagnosticsReport
+from hm_pyhelper.constants.shipping import DESTINATION_NAME_KEY, DESTINATION_WALLETS_KEY
+from hw_diag.utilities.hardware import get_nebra_json
+
+
+class BaseAddGatewayTxnDiagnostic(Diagnostic):
+    """
+    Helper logic related to loading Nebra JSON. Also introduces a 'steps' pattern that
+    may be worth moving to Diagnostic in the future.
+
+    Intended to be extended in order to generate and acknowledge AddGatewayTxns.
+    """
+
+    def __init__(self, key, friendly_key):
+        super(BaseAddGatewayTxnDiagnostic, self).__init__(key, friendly_key)
+
+    def load_and_validate_nebra_json(self) -> bool:
+        """
+        Load nebra.json file and record failure if file could not be opened.
+        Returns True if file opens successfully.
+        """
+        self.nebra_json = get_nebra_json()
+
+        if self.nebra_json is None:
+            msg = "Nebra JSON could not be loaded or is empty."
+            self.diagnostics_report.record_failure(msg, self)
+            return False
+        else:
+            return True
+
+    def load_and_validate_destination_wallets(self) -> bool:
+        """
+        1. Ensure a destination name is set.
+        2. Validate presence of destination wallets.
+        3. Ensure destination wallets is not empty or None.
+
+        Record failure and return False if conditions above not met, return True otherwise.
+        """
+
+        if DESTINATION_NAME_KEY not in self.nebra_json:
+            msg = "Destination name not found in Nebra JSON."
+            self.diagnostics_report.record_failure(msg, self)
+            return False
+        if DESTINATION_WALLETS_KEY not in self.nebra_json:
+            # Check that destination wallets are present
+            msg = "Destination wallets not found in Nebra JSON."
+            self.diagnostics_report.record_failure(msg, self)
+            return False
+        else:
+            self.destination_wallets = self.nebra_json[DESTINATION_WALLETS_KEY]
+            # Check if destination wallets contains at least one valid address
+            if self.destination_wallets is None or \
+               len(self.destination_wallets) == 0:
+                msg = "Destination wallets array is empty in Nebra JSON."
+                self.diagnostics_report.record_failure(msg, self)
+                return False
+            return True
+
+    def get_steps(self) -> list:
+        """
+        For extending classes to implement. Must return an array of methods to
+        be executed in order. Each method is responsible for returning True if
+        successful. Steps are responsible for invoking record_result or
+        record_failure as necessary.
+        """
+        return []
+
+    def perform_test(self, diagnostics_report: DiagnosticsReport) -> bool:
+        """
+        Iterate through all steps. Exit immediately if an error is encountered.
+        """
+        self.diagnostics_report = diagnostics_report
+
+        steps = self.get_steps()
+        try:
+            for step in steps:
+                if not step():
+                    return
+
+        except Exception as e:
+            self.diagnostics_report.record_failure(e, self)

--- a/hw_diag/diagnostics/add_gateway_txn/gen_add_gateway_txn_diagnostic.py
+++ b/hw_diag/diagnostics/add_gateway_txn/gen_add_gateway_txn_diagnostic.py
@@ -1,0 +1,65 @@
+import random
+
+from hm_pyhelper.miner_json_rpc import MinerClient
+from hm_pyhelper.constants.shipping import DESTINATION_ADD_GATEWAY_TXN_KEY
+from hm_pyhelper.constants.nebra import NEBRA_WALLET_ADDRESS
+from .base_add_gateway_txn_diagnostic import BaseAddGatewayTxnDiagnostic
+
+
+class GenAddGatewayTxnDiagnostic(BaseAddGatewayTxnDiagnostic):
+    """
+    Generates an add_gateway_txn if a destination name and wallets are defined and valid.
+    Diagnostics report will be in the format below if successful.
+
+    https://docs.helium.com/mine-hnt/full-hotspots/become-a-maker/hotspot-integration-testing/#generate-an-add-hotspot-transaction
+    {
+        errors: [],
+        DESTINATION_ADD_GATEWAY_TXN_KEY: {
+            "address": "11TL62V8NYvSTXmV5CZCjaucskvNR1Fdar1Pg4Hzmzk5tk2JBac",
+            "fee": 65000,
+            "owner": "14GWyFj9FjLHzoN3aX7Tq7PL6fEg4dfWPY8CrK8b9S5ZrcKDz6S",
+            "payer": "138LbePH4r7hWPuTnK6HXVJ8ATM2QU71iVHzLTup1UbnPDvbxmr",
+            "staking fee": 4000000,
+            "txn": "CrkBCiEBrlImpYLbJ0z0hw5b4g9isRyPrgbXs9X+RrJ4pJJc9MkS..."
+        }
+    }
+    """
+
+    def __init__(self):
+        super(GenAddGatewayTxnDiagnostic, self). \
+            __init__(DESTINATION_ADD_GATEWAY_TXN_KEY, DESTINATION_ADD_GATEWAY_TXN_KEY)
+
+    def select_and_validate_one_destination_wallet(self) -> bool:
+        """
+        Randomly pick a destination wallet and ensure it is not empty.
+        """
+        self.destination_wallet = random.choice(self.destination_wallets)
+        is_destination_wallet_valid = self.destination_wallet is not None and \
+            len(self.destination_wallet) > 1
+
+        if not is_destination_wallet_valid:
+            msg = f'Wallet selected as owner is invalid ({self.destination_wallet})'
+            self.diagnostics_report.record_failure(msg, self)
+            return False
+        else:
+            return True
+
+    def gen_add_gateway_txn(self) -> bool:
+        """
+        Gen add_gateway_txn over RPC. This may raise an exception, which should be handled
+        by the caller.
+        """
+        # Send json RPC request to create gateway transaction
+        miner_rpc = MinerClient()
+        add_gateway_txn = miner_rpc.create_add_gateway_txn(self.destination_wallet,
+                                                           NEBRA_WALLET_ADDRESS)
+        self.diagnostics_report.record_result(add_gateway_txn, self)
+        return True
+
+    def get_steps(self) -> list:
+        return [
+            self.load_and_validate_nebra_json,
+            self.load_and_validate_destination_wallets,
+            self.select_and_validate_one_destination_wallet,
+            self.gen_add_gateway_txn
+        ]

--- a/hw_diag/diagnostics/json_expected_key_diagnostic.py
+++ b/hw_diag/diagnostics/json_expected_key_diagnostic.py
@@ -1,0 +1,33 @@
+from hm_pyhelper.diagnostics import Diagnostic, DiagnosticsReport
+
+
+class JsonExpectedKeyDiagnostic(Diagnostic):
+    """
+    Record result if `key` is present and not empty in `nebra_json`.
+    """
+    def __init__(self, key, json_dict: dict):
+        super(JsonExpectedKeyDiagnostic, self).__init__(key, key)
+        self.json_dict = json_dict
+
+    def perform_test(self, diagnostics_report: DiagnosticsReport):
+        if self.json_dict is None:
+            diagnostics_report.record_failure("JSON is empty.", self)
+            return
+
+        if self.key in self.json_dict:
+            json_val = self.json_dict[self.key]
+
+            if len(json_val) > 0:
+                # Key is present and not empty
+                diagnostics_report.record_result(json_val, self)
+                return
+            else:
+                # Key is present but empty
+                diagnostics_report.record_failure(f"The value for key \"{self.key}\" "
+                                                  "in JSON is empty.", self)
+                return
+        else:
+            # Missing key
+            diagnostics_report.record_failure(f"JSON file does not contain key \"{self.key}\".",
+                                              self)
+            return

--- a/hw_diag/diagnostics/nebra_json_diagnostics.py
+++ b/hw_diag/diagnostics/nebra_json_diagnostics.py
@@ -1,0 +1,35 @@
+from hm_pyhelper.diagnostics import DiagnosticsReport
+from hm_pyhelper.constants.diagnostics import VARIANT_KEY, FREQUENCY_KEY, DISK_IMAGE_KEY
+from hm_pyhelper.constants.shipping import DESTINATION_NAME_KEY
+from .json_expected_key_diagnostic import JsonExpectedKeyDiagnostic
+from hw_diag.utilities.hardware import get_nebra_json
+
+
+class NebraJsonDiagnostics():
+    """
+    Copies values from nebra.json file found to a DiagnosticsReport.
+    When constructing a new DiagnosticsReport, place NebraJsonDiagnostic after EnvVarDiagnostics
+    in order to overwrite values.
+    """
+    # Destination wallets omitted because it will never be copied to a DiagnosticsReport.
+    NEBRA_JSON_EXPECTED_KEYS = [VARIANT_KEY,
+                                FREQUENCY_KEY,
+                                DISK_IMAGE_KEY,
+                                DESTINATION_NAME_KEY]
+
+    def gen_expected_key_diagnostics(self):
+        self.nebra_json = get_nebra_json()
+
+        def gen_expected_key_diagnostic(key):
+            return JsonExpectedKeyDiagnostic(key, self.nebra_json)
+
+        self.nebra_json_diagnostics = map(gen_expected_key_diagnostic,
+                                          self.NEBRA_JSON_EXPECTED_KEYS)
+
+    def perform_expected_key_tests(self, diagnostics_report: DiagnosticsReport):
+        for nebra_json_diagnostic in self.nebra_json_diagnostics:
+            nebra_json_diagnostic.perform_test(diagnostics_report)
+
+    def perform_test(self, diagnostics_report: DiagnosticsReport):
+        self.gen_expected_key_diagnostics()
+        self.perform_expected_key_tests(diagnostics_report)

--- a/hw_diag/tests/diagnostics/test_bt_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_bt_diagnostic.py
@@ -4,7 +4,7 @@ from dbus import DBusException
 
 from hm_pyhelper.diagnostics.diagnostics_report import \
     DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
-
+from hm_pyhelper.constants.diagnostics import BLUETOOTH_KEY
 from hw_diag.diagnostics.bt_diagnostic import BtDiagnostic
 
 
@@ -78,7 +78,7 @@ class TestBtDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['BT'],
+            DIAGNOSTICS_ERRORS_KEY: ['BT', BLUETOOTH_KEY],
             'BT': 'Bluez is working but, no Bluetooth devices detected.',
             'bluetooth': 'Bluez is working but, no Bluetooth devices detected.'
         })
@@ -99,7 +99,7 @@ class TestBtDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['BT'],
+            DIAGNOSTICS_ERRORS_KEY: ['BT', BLUETOOTH_KEY],
             'BT': 'Not authorized',
             'bluetooth': 'Not authorized'
         })

--- a/hw_diag/tests/diagnostics/test_ecc_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_ecc_diagnostic.py
@@ -7,6 +7,7 @@ from hw_diag.diagnostics.ecc_diagnostic import EccDiagnostic
 from hm_pyhelper.exceptions import ECCMalfunctionException,\
     GatewayMFRFileNotFoundException
 from hm_pyhelper.lock_singleton import ResourceBusyError
+from hm_pyhelper.constants.diagnostics import ECC_KEY
 
 
 class TestECCDiagnostic(unittest.TestCase):
@@ -34,7 +35,7 @@ class TestECCDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['ECC'],
+            DIAGNOSTICS_ERRORS_KEY: [ECC_KEY, ECC_KEY],
             'ECC': 'gateway_mfr test finished with error, {"result": "fail"}'
         })
 
@@ -48,7 +49,7 @@ class TestECCDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['ECC'],
+            DIAGNOSTICS_ERRORS_KEY: [ECC_KEY, ECC_KEY],
             'ECC': 'ECC Malfunctioned'
         })
 
@@ -63,7 +64,7 @@ class TestECCDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['ECC'],
+            DIAGNOSTICS_ERRORS_KEY: [ECC_KEY, ECC_KEY],
             'ECC': 'Gateway MFR File Not Found'
         })
 
@@ -77,6 +78,6 @@ class TestECCDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['ECC'],
+            DIAGNOSTICS_ERRORS_KEY: [ECC_KEY, ECC_KEY],
             'ECC': 'Resource Busy Error'
         })

--- a/hw_diag/tests/diagnostics/test_env_var_diagnostics.py
+++ b/hw_diag/tests/diagnostics/test_env_var_diagnostics.py
@@ -29,7 +29,7 @@ class TestEnvVarDiagnostics(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['DIAGNOSTIC_KEY'],
+            DIAGNOSTICS_ERRORS_KEY: ['DIAGNOSTIC_KEY', 'ENV_VAR'],
             'DIAGNOSTIC_KEY': 'Env var ENV_VAR not set',
             'ENV_VAR': 'Env var ENV_VAR not set'
         })

--- a/hw_diag/tests/diagnostics/test_json_expected_key_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_json_expected_key_diagnostic.py
@@ -1,0 +1,55 @@
+import unittest
+
+from hm_pyhelper.diagnostics.diagnostics_report import \
+    DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+from hw_diag.diagnostics.json_expected_key_diagnostic import JsonExpectedKeyDiagnostic
+
+
+class TestJsonExpectedKeyDiagnostic(unittest.TestCase):
+    def test_success(self):
+        json_dict = {'foo': 'bar'}
+        diagnostic = JsonExpectedKeyDiagnostic('foo', json_dict)
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'foo': 'bar'
+        })
+
+    def test_json_none(self):
+        json_dict = None
+        diagnostic = JsonExpectedKeyDiagnostic('foo', json_dict)
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['foo', 'foo'],
+            'foo': 'JSON is empty.'
+        })
+
+    def test_missing_key(self):
+        json_dict = {'foo': 'bar'}
+        diagnostic = JsonExpectedKeyDiagnostic('missing', json_dict)
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['missing', 'missing'],
+            'missing': 'JSON file does not contain key "missing".'
+        })
+
+    def test_empty_key(self):
+        json_dict = {'foo': ''}
+        diagnostic = JsonExpectedKeyDiagnostic('foo', json_dict)
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['foo', 'foo'],
+            'foo': 'The value for key "foo" in JSON is empty.'
+        })

--- a/hw_diag/tests/diagnostics/test_key_diagnostics.py
+++ b/hw_diag/tests/diagnostics/test_key_diagnostics.py
@@ -35,7 +35,7 @@ class TestKeyDiagnostics(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['KK'],
+            DIAGNOSTICS_ERRORS_KEY: ['KK', 'test_key'],
             'KK': 'Key key_location not found',
             'test_key': 'Key key_location not found'
         })

--- a/hw_diag/tests/diagnostics/test_lora_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_lora_diagnostic.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from hm_pyhelper.diagnostics.diagnostics_report import \
     DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+from hm_pyhelper.constants.diagnostics import LORA_KEY
 from hw_diag.diagnostics.lora_diagnostic import LoraDiagnostic
 
 
@@ -32,7 +33,7 @@ class TestLoraDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['LOR'],
+            DIAGNOSTICS_ERRORS_KEY: ['LOR', LORA_KEY],
             'LOR': False,
             'lora': False
         })

--- a/hw_diag/tests/diagnostics/test_lte_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_lte_diagnostic.py
@@ -4,7 +4,7 @@ from dbus import DBusException
 
 from hm_pyhelper.diagnostics.diagnostics_report import \
     DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
-
+from hm_pyhelper.constants.diagnostics import LTE_KEY
 from hw_diag.diagnostics.lte_diagnostic import LteDiagnostic
 
 
@@ -63,7 +63,7 @@ class TestLteDiagnostics(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['LTE'],
+            DIAGNOSTICS_ERRORS_KEY: ['LTE', LTE_KEY],
             'LTE': 'ModemManager is working but, no LTE devices detected.',
             'lte': 'ModemManager is working but, no LTE devices detected.'
         })
@@ -84,7 +84,7 @@ class TestLteDiagnostics(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['LTE'],
+            DIAGNOSTICS_ERRORS_KEY: ['LTE', LTE_KEY],
             'LTE': 'Not authorized',
             'lte': 'Not authorized'
         })

--- a/hw_diag/tests/diagnostics/test_mac_diagnostics.py
+++ b/hw_diag/tests/diagnostics/test_mac_diagnostics.py
@@ -2,7 +2,7 @@ import unittest
 from unittest.mock import patch, mock_open
 from hm_pyhelper.diagnostics.diagnostics_report import \
     DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
-
+from hm_pyhelper.constants.diagnostics import ETH_MAC_ADDRESS_KEY, WIFI_MAC_ADDRESS_KEY
 from hw_diag.diagnostics.mac_diagnostics import MacDiagnostic, MacDiagnostics
 
 
@@ -31,7 +31,7 @@ class TestMacDiagnostics(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['I0'],
+            DIAGNOSTICS_ERRORS_KEY: ['I0', 'friendly'],
             'I0': 'No file',
             'friendly': 'No file'
         })
@@ -61,7 +61,7 @@ class TestMacDiagnostics(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['E0', 'W0'],
+            DIAGNOSTICS_ERRORS_KEY: ['E0', ETH_MAC_ADDRESS_KEY, 'W0', WIFI_MAC_ADDRESS_KEY],
             'E0': 'File Not Found Error',
             'eth_mac_address': 'File Not Found Error',
             'W0': 'File Not Found Error',
@@ -77,7 +77,7 @@ class TestMacDiagnostics(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['E0', 'W0'],
+            DIAGNOSTICS_ERRORS_KEY: ['E0', ETH_MAC_ADDRESS_KEY, 'W0', WIFI_MAC_ADDRESS_KEY],
             'E0': 'Permission Error',
             'eth_mac_address': 'Permission Error',
             'W0': 'Permission Error',

--- a/hw_diag/tests/diagnostics/test_nebra_json_diagnostics.py
+++ b/hw_diag/tests/diagnostics/test_nebra_json_diagnostics.py
@@ -1,0 +1,51 @@
+import unittest
+from unittest.mock import patch
+
+from hm_pyhelper.diagnostics.diagnostics_report import \
+    DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+from hm_pyhelper.constants.diagnostics import VARIANT_KEY, FREQUENCY_KEY, DISK_IMAGE_KEY
+from hm_pyhelper.constants.shipping import DESTINATION_NAME_KEY
+from hw_diag.diagnostics.nebra_json_diagnostics import NebraJsonDiagnostics
+
+
+class TestNebraJsonDiagnostics(unittest.TestCase):
+    NEBRA_JSON_SUCCESS = {
+        VARIANT_KEY: 'variant',
+        FREQUENCY_KEY: 'frequency',
+        DISK_IMAGE_KEY: 'disk_image',
+        DESTINATION_NAME_KEY: 'destination_name'
+    }
+
+    @patch("hw_diag.diagnostics.nebra_json_diagnostics.get_nebra_json",
+           return_value=NEBRA_JSON_SUCCESS)
+    def test_success(self, get_nebra_json_mock):
+        diagnostic = NebraJsonDiagnostics()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            VARIANT_KEY: 'variant',
+            FREQUENCY_KEY: 'frequency',
+            DISK_IMAGE_KEY: 'disk_image',
+            DESTINATION_NAME_KEY: 'destination_name'
+        })
+
+    @patch("hw_diag.diagnostics.nebra_json_diagnostics.get_nebra_json",
+           return_value=None)
+    def test_invalid_file(self, get_nebra_json_mock):
+        diagnostic = NebraJsonDiagnostics()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: [VARIANT_KEY, VARIANT_KEY, FREQUENCY_KEY, FREQUENCY_KEY,
+                                     DISK_IMAGE_KEY, DISK_IMAGE_KEY,
+                                     DESTINATION_NAME_KEY, DESTINATION_NAME_KEY],
+            VARIANT_KEY: 'JSON is empty.',
+            FREQUENCY_KEY: 'JSON is empty.',
+            DISK_IMAGE_KEY: 'JSON is empty.',
+            DESTINATION_NAME_KEY: 'JSON is empty.'
+        })

--- a/hw_diag/tests/diagnostics/test_pf_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_pf_diagnostic.py
@@ -32,7 +32,7 @@ class TestPfDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['PF'],
+            DIAGNOSTICS_ERRORS_KEY: ['PF', 'legacy_pass_fail'],
             'PF': False,
             'legacy_pass_fail': False,
         })

--- a/hw_diag/tests/diagnostics/test_serial_number_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_serial_number_diagnostic.py
@@ -3,6 +3,7 @@ from unittest.mock import patch, mock_open
 
 from hm_pyhelper.diagnostics.diagnostics_report import \
     DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+from hm_pyhelper.constants.diagnostics import SERIAL_NUMBER_KEY
 from hw_diag.diagnostics.serial_number_diagnostic import SerialNumberDiagnostic
 
 VALID_CPU_PROC = """00000000ddd1a4c2"""
@@ -46,7 +47,7 @@ class TestSerialNumberDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['serial_number'],
+            DIAGNOSTICS_ERRORS_KEY: ['serial_number', SERIAL_NUMBER_KEY],
             'serial_number': 'File not found',
             'serial_number': 'File not found'
         })
@@ -60,7 +61,7 @@ class TestSerialNumberDiagnostic(unittest.TestCase):
 
         self.assertDictEqual(diagnostics_report, {
             DIAGNOSTICS_PASSED_KEY: False,
-            DIAGNOSTICS_ERRORS_KEY: ['serial_number'],
+            DIAGNOSTICS_ERRORS_KEY: ['serial_number', SERIAL_NUMBER_KEY],
             'serial_number': 'Bad permissions',
             'serial_number': 'Bad permissions'
         })

--- a/hw_diag/tests/test_ack_add_gateway_txn.py
+++ b/hw_diag/tests/test_ack_add_gateway_txn.py
@@ -1,0 +1,78 @@
+import unittest
+from unittest.mock import patch
+from hm_pyhelper.diagnostics.diagnostics_report import DIAGNOSTICS_ERRORS_KEY, \
+                                                       DIAGNOSTICS_PASSED_KEY
+from hm_pyhelper.constants.shipping import DESTINATION_NAME_KEY, DESTINATION_WALLETS_KEY
+from hm_pyhelper.constants.diagnostics import VARIANT_KEY, FREQUENCY_KEY, DISK_IMAGE_KEY
+
+# Test cases
+from hw_diag.app import get_app
+
+
+class TestAckAddGatewayTxn(unittest.TestCase):
+
+    def setUp(self):
+        self.app = get_app('test_app')
+        self.client = self.app.test_client()
+
+    def mock_create_add_gateway_txn(self, owner_address: str, payer_address: str):
+        return {
+            "address": "TestAddress",
+            "fee": 65000,
+            "owner": owner_address,
+            "payer": payer_address,
+            "staking fee": 4000000,
+            "txn": "CrkBCiEBrlImpYLbJ0z0hw5b4g9isRyPrgbXs9X+RrJ4pJJc9MkS..."
+        }
+
+    NEBRA_JSON_SUCCESS = {
+        VARIANT_KEY: 'variant',
+        FREQUENCY_KEY: 'frequency',
+        DISK_IMAGE_KEY: 'disk_image',
+        DESTINATION_NAME_KEY: 'destination_name',
+        DESTINATION_WALLETS_KEY: ['owner_address']
+    }
+
+    @patch("hw_diag.diagnostics.add_gateway_txn.base_add_gateway_txn_diagnostic.get_nebra_json",
+           return_value=NEBRA_JSON_SUCCESS)
+    @patch("hw_diag.diagnostics.add_gateway_txn.ack_add_gateway_txn_diagnostic.remove_destination_wallets_from_nebra_json",  # noqa: E501
+           return_value=NEBRA_JSON_SUCCESS)
+    def test_success(self, nebra_json_mock, remove_nebra_json_mock):
+        # Check the diagnostics JSON output.
+        endpoint = '/v1/ack_add_gateway_txn'
+
+        resp = self.client.post(endpoint)
+        self.assertEqual(resp.status_code, 200)
+
+        expected_payload = {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+        }
+        self.assertDictEqual(resp.json, expected_payload)
+        self.assertEqual(
+            resp.headers.get('Content-Type'),
+            'application/json'
+        )
+
+    @patch("hw_diag.diagnostics.add_gateway_txn.base_add_gateway_txn_diagnostic.get_nebra_json",
+           return_value=NEBRA_JSON_SUCCESS)
+    @patch("hw_diag.diagnostics.add_gateway_txn.ack_add_gateway_txn_diagnostic.remove_destination_wallets_from_nebra_json",  # noqa: E501
+           side_effect=Exception('Cannot remove'))
+    def test_failure(self, nebra_json_mock, remove_nebra_json_mock):
+        # Check the diagnostics JSON output.
+        endpoint = '/v1/ack_add_gateway_txn'
+
+        resp = self.client.post(endpoint)
+        self.assertEqual(resp.status_code, 406)
+
+        expected_payload = {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: [DESTINATION_WALLETS_KEY,
+                                     DESTINATION_WALLETS_KEY],
+            DESTINATION_WALLETS_KEY: "Cannot remove"
+        }
+        self.assertDictEqual(resp.json, expected_payload)
+        self.assertEqual(
+            resp.headers.get('Content-Type'),
+            'application/json'
+        )

--- a/hw_diag/tests/test_gen_add_gateway_txn.py
+++ b/hw_diag/tests/test_gen_add_gateway_txn.py
@@ -1,0 +1,211 @@
+import unittest
+from unittest.mock import patch
+import hm_pyhelper.miner_json_rpc.client
+from hm_pyhelper.diagnostics.diagnostics_report import DIAGNOSTICS_ERRORS_KEY, \
+                                                       DIAGNOSTICS_PASSED_KEY
+from hm_pyhelper.constants.shipping import DESTINATION_NAME_KEY, DESTINATION_WALLETS_KEY, \
+                                           DESTINATION_ADD_GATEWAY_TXN_KEY
+from hm_pyhelper.constants.diagnostics import VARIANT_KEY, FREQUENCY_KEY, DISK_IMAGE_KEY
+from hm_pyhelper.constants.nebra import NEBRA_WALLET_ADDRESS
+
+# Test cases
+from hw_diag.app import get_app
+
+
+class TestGenAddGatewayTxn(unittest.TestCase):
+
+    def setUp(self):
+        self.app = get_app('test_app')
+        self.client = self.app.test_client()
+
+    def mock_create_add_gateway_txn(self, owner_address: str, payer_address: str):
+        return {
+            "address": "TestAddress",
+            "fee": 65000,
+            "owner": owner_address,
+            "payer": payer_address,
+            "staking fee": 4000000,
+            "txn": "CrkBCiEBrlImpYLbJ0z0hw5b4g9isRyPrgbXs9X+RrJ4pJJc9MkS..."
+        }
+
+    NEBRA_JSON_SUCCESS = {
+        VARIANT_KEY: 'variant',
+        FREQUENCY_KEY: 'frequency',
+        DISK_IMAGE_KEY: 'disk_image',
+        DESTINATION_NAME_KEY: 'destination_name',
+        DESTINATION_WALLETS_KEY: ['owner_address']
+    }
+
+    @patch("hw_diag.diagnostics.add_gateway_txn.base_add_gateway_txn_diagnostic.get_nebra_json",
+           return_value=NEBRA_JSON_SUCCESS)
+    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'create_add_gateway_txn',
+                  mock_create_add_gateway_txn)
+    def test_success(self, nebra_json_mock):
+        # Check the diagnostics JSON output.
+        endpoint = '/v1/gen_add_gateway_txn'
+
+        resp = self.client.post(endpoint)
+        self.assertEqual(resp.status_code, 200)
+
+        expected_payload = {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            DESTINATION_ADD_GATEWAY_TXN_KEY: {
+                "address": "TestAddress",
+                "fee": 65000,
+                "owner": "owner_address",
+                "payer": NEBRA_WALLET_ADDRESS,
+                "staking fee": 4000000,
+                "txn": "CrkBCiEBrlImpYLbJ0z0hw5b4g9isRyPrgbXs9X+RrJ4pJJc9MkS..."
+            }
+        }
+        self.assertDictEqual(resp.json, expected_payload)
+        self.assertEqual(
+            resp.headers.get('Content-Type'),
+            'application/json'
+        )
+
+    @patch("hw_diag.diagnostics.add_gateway_txn.base_add_gateway_txn_diagnostic.get_nebra_json",
+           return_value=None)
+    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'create_add_gateway_txn',
+                  mock_create_add_gateway_txn)
+    def test_nebra_json_empty(self, nebra_json_mock):
+        # Check the diagnostics JSON output.
+        endpoint = '/v1/gen_add_gateway_txn'
+
+        resp = self.client.post(endpoint)
+        self.assertEqual(resp.status_code, 406)
+
+        expected_payload = {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: [DESTINATION_ADD_GATEWAY_TXN_KEY,
+                                     DESTINATION_ADD_GATEWAY_TXN_KEY],
+            DESTINATION_ADD_GATEWAY_TXN_KEY: "Nebra JSON could not be loaded or is empty."
+        }
+        self.assertDictEqual(resp.json, expected_payload)
+        self.assertEqual(
+            resp.headers.get('Content-Type'),
+            'application/json'
+        )
+
+    NEBRA_JSON_DESTINATION_NAME_MISSING = {
+        VARIANT_KEY: 'variant',
+        FREQUENCY_KEY: 'frequency',
+        DISK_IMAGE_KEY: 'disk_image',
+        DESTINATION_WALLETS_KEY: ['owner_address']
+    }
+
+    @patch("hw_diag.diagnostics.add_gateway_txn.base_add_gateway_txn_diagnostic.get_nebra_json",
+           return_value=NEBRA_JSON_DESTINATION_NAME_MISSING)
+    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'create_add_gateway_txn',
+                  mock_create_add_gateway_txn)
+    def test_destination_name_missing(self, nebra_json_mock):
+        # Check the diagnostics JSON output.
+        endpoint = '/v1/gen_add_gateway_txn'
+
+        resp = self.client.post(endpoint)
+        self.assertEqual(resp.status_code, 406)
+
+        expected_payload = {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: [DESTINATION_ADD_GATEWAY_TXN_KEY,
+                                     DESTINATION_ADD_GATEWAY_TXN_KEY],
+            DESTINATION_ADD_GATEWAY_TXN_KEY: "Destination name not found in Nebra JSON."
+        }
+        self.assertDictEqual(resp.json, expected_payload)
+        self.assertEqual(
+            resp.headers.get('Content-Type'),
+            'application/json'
+        )
+
+    NEBRA_JSON_DESTINATION_WALLETS_EMPTY = {
+        VARIANT_KEY: 'variant',
+        FREQUENCY_KEY: 'frequency',
+        DISK_IMAGE_KEY: 'disk_image',
+        DESTINATION_NAME_KEY: 'destination_name',
+        DESTINATION_WALLETS_KEY: []
+    }
+
+    @patch("hw_diag.diagnostics.add_gateway_txn.base_add_gateway_txn_diagnostic.get_nebra_json",
+           return_value=NEBRA_JSON_DESTINATION_WALLETS_EMPTY)
+    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'create_add_gateway_txn',
+                  mock_create_add_gateway_txn)
+    def test_destination_wallets_empty(self, nebra_json_mock):
+        # Check the diagnostics JSON output.
+        endpoint = '/v1/gen_add_gateway_txn'
+
+        resp = self.client.post(endpoint)
+        self.assertEqual(resp.status_code, 406)
+
+        expected_payload = {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: [DESTINATION_ADD_GATEWAY_TXN_KEY,
+                                     DESTINATION_ADD_GATEWAY_TXN_KEY],
+            DESTINATION_ADD_GATEWAY_TXN_KEY: "Destination wallets array is empty in Nebra JSON."
+        }
+        self.assertDictEqual(resp.json, expected_payload)
+        self.assertEqual(
+            resp.headers.get('Content-Type'),
+            'application/json'
+        )
+
+    NEBRA_JSON_DESTINATION_WALLETS_MISSING = {
+        VARIANT_KEY: 'variant',
+        FREQUENCY_KEY: 'frequency',
+        DISK_IMAGE_KEY: 'disk_image',
+        DESTINATION_NAME_KEY: 'destination_name'
+    }
+
+    @patch("hw_diag.diagnostics.add_gateway_txn.base_add_gateway_txn_diagnostic.get_nebra_json",
+           return_value=NEBRA_JSON_DESTINATION_WALLETS_MISSING)
+    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'create_add_gateway_txn',
+                  mock_create_add_gateway_txn)
+    def test_destination_wallets_missing(self, nebra_json_mock):
+        # Check the diagnostics JSON output.
+        endpoint = '/v1/gen_add_gateway_txn'
+
+        resp = self.client.post(endpoint)
+        self.assertEqual(resp.status_code, 406)
+
+        expected_payload = {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: [DESTINATION_ADD_GATEWAY_TXN_KEY,
+                                     DESTINATION_ADD_GATEWAY_TXN_KEY],
+            DESTINATION_ADD_GATEWAY_TXN_KEY: "Destination wallets not found in Nebra JSON."
+        }
+        self.assertDictEqual(resp.json, expected_payload)
+        self.assertEqual(
+            resp.headers.get('Content-Type'),
+            'application/json'
+        )
+
+    NEBRA_JSON_DESTINATION_WALLETS_INVALID = {
+        VARIANT_KEY: 'variant',
+        FREQUENCY_KEY: 'frequency',
+        DISK_IMAGE_KEY: 'disk_image',
+        DESTINATION_NAME_KEY: 'destination_name',
+        DESTINATION_WALLETS_KEY: ['']
+    }
+
+    @patch("hw_diag.diagnostics.add_gateway_txn.base_add_gateway_txn_diagnostic.get_nebra_json",
+           return_value=NEBRA_JSON_DESTINATION_WALLETS_INVALID)
+    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'create_add_gateway_txn',
+                  mock_create_add_gateway_txn)
+    def test_destination_wallets_invalid(self, nebra_json_mock):
+        # Check the diagnostics JSON output.
+        endpoint = '/v1/gen_add_gateway_txn'
+
+        resp = self.client.post(endpoint)
+        self.assertEqual(resp.status_code, 406)
+
+        expected_payload = {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: [DESTINATION_ADD_GATEWAY_TXN_KEY,
+                                     DESTINATION_ADD_GATEWAY_TXN_KEY],
+            DESTINATION_ADD_GATEWAY_TXN_KEY: "Wallet selected as owner is invalid ()"
+        }
+        self.assertDictEqual(resp.json, expected_payload)
+        self.assertEqual(
+            resp.headers.get('Content-Type'),
+            'application/json'
+        )

--- a/hw_diag/utilities/hardware.py
+++ b/hw_diag/utilities/hardware.py
@@ -1,9 +1,14 @@
-from time import sleep
 import dbus
+import json
+from time import sleep
+
 from hm_pyhelper.logger import get_logger
 from hm_pyhelper.miner_param import get_public_keys_rust
 from hm_pyhelper.hardware_definitions import variant_definitions, is_rockpi
+
 from hw_diag.utilities.shell import config_search_param
+from hm_pyhelper.constants.nebra import NEBRA_JSON_FILEPATH
+from hm_pyhelper.constants.shipping import DESTINATION_WALLETS_KEY
 
 logging = get_logger(__name__)
 
@@ -266,6 +271,32 @@ def get_public_keys_and_ignore_errors():
         }
 
     return public_keys
+
+
+def get_nebra_json() -> dict:
+    """
+    Loads nebra.json file and deserialized into JSON.
+    Returns None if file cannot be openend.
+    """
+    # Load Nebra JSON file contents
+    try:
+        with open(NEBRA_JSON_FILEPATH) as json_file:
+            return json.load(json_file)
+    except Exception as e:
+        logging.error(e)
+        return None
+
+
+def remove_destination_wallets_from_nebra_json() -> dict:
+    """
+    Removes DESTINATION_WALLETS_KEY from NEBRA_JSON_FILEPATH.
+    """
+    # Load Nebra JSON file contents
+    with open(NEBRA_JSON_FILEPATH, 'w') as json_file:
+        nebra_json = json.load(json_file)
+        del nebra_json[DESTINATION_WALLETS_KEY]
+        json.dump(nebra_json, json_file)
+        return nebra_json
 
 
 if __name__ == '__main__':

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ requests==2.26.0
 retry==0.9.2
 sentry-sdk[Flask]==1.5.1
 dbus-python==1.2.16
-hm-pyhelper==0.12.2
+hm-pyhelper==0.13.7


### PR DESCRIPTION
**Issue**

- Link: #283 
- Summary: Create diagnostics and API endpoints for nebra.json and add_gateway_txn.

**How**
- Created NebraJsonDiagnostics to copy values from nebra.json to a DiagnosticsReport.
- Created GenAddGatewayTxn and AckAddGatewayTxn to generated an add_gateway_txn and to remove destination wallets once complete.
- Updated tests that expect friendly_keys to be in errors array following pyhelper update.

**References**
[Generation of Nebra.json file](https://github.com/NebraLtd/hotspot-production-images/issues/26)
[hm-pyhelper JSON RPC function for generation of gateway transaction](https://github.com/NebraLtd/hm-pyhelper/issues/91)

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [x] Thought about variable and method names
