### PR TITLE
feat: add EG25G firmware and flashing tool (#133)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,4 +65,4 @@ COPY --from=builder /tmp/build/quectel /quectel
 ENV PYTHONPATH="${PYTHON_DEPENDENCIES_DIR}:${PYTHONPATH}"
 ENV PATH="${PYTHON_DEPENDENCIES_DIR}/bin:${PATH}"
 
-ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:5000", "hw_diag:wsgi_app"]
+ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:5000", "--timeout", "300", "hw_diag:wsgi_app"]


### PR DESCRIPTION
* added modem ports to diagnostic container

**133**

- Link: https://github.com/NebraLtd/hm-diag/issues/133
- Summary: qfirehose needs these ports to flash the firmware

**How**
<!-- exposes /dev/ttyUSB[0-4] to the diagnostic container -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names