### PR TITLE
feat: pull key storage bus from hardware def

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,4 +8,4 @@ requests==2.26.0
 retry==0.9.2
 sentry-sdk[Flask]==1.5.1
 dbus-python==1.2.16
-hm-pyhelper==0.13.10
+hm-pyhelper==0.13.13


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-pyhelper/pull/84
- Summary: ECC was hard coded

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Instead of hard coding the key storage bus for ECC we will now make it pull in from pyhelper module

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Relates-to: https://github.com/NebraLtd/hm-pyhelper/pull/84

Co-authored-by: radicale <radicale@users.noreply.github.com>

https://github.com/radicale/hm-diag/commit/a3fd21c22dc6230a32518dab347adb3a868e790d

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [x] Documentation added
- [x] Thought about variable and method names

