### PR TITLE
Fix Support Link in Footer

### DIFF
--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -188,7 +188,7 @@
       {% else %}
         <p>Last Updated: Never</p>
       {% endif %}
-      <p>To get support please visit <a href="https://nebra.io/helium-support">https://nebra.io/helium-support</a></p>
+      <p>To get support please visit <a href="https://helium.nebra.com/">https://helium.nebra.com/</a></p>
       <p><a href="/json">Download Diagnostics Info for Support</a></p>
       <p>&copy; Nebra LTD. 2020-{{ now.year }}<p>
     </div>


### PR DESCRIPTION
**Issue**
- Link: N/A
- Summary: The support link in the footer was pointing to a 404 page (https://nebra.io/helium-support). I assume the link I replaced it with (https://helium.nebra.com/) is the correct one, but I'll leave that to the Nebra team to confirm or correct.

**How**
- Fix support URL in the footer.

**Screenshots**
Old:
![image](https://user-images.githubusercontent.com/8300089/158279551-db32fcb3-333e-4702-8763-cf055291fd2f.png)

New:
![image](https://user-images.githubusercontent.com/8300089/158279652-a7d15ea8-5d5c-48f8-bccf-d559c5ce7508.png)

**References**
N/A

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

