### PR TITLE
fix: use appState to check device status

### DIFF
--- a/hw_diag/diagnostics/device_status_diagnostic.py
+++ b/hw_diag/diagnostics/device_status_diagnostic.py
@@ -19,12 +19,12 @@ class DeviceStatusDiagnostic(Diagnostic):
     def perform_test(self, diagnostics_report: DiagnosticsReport) -> None:
         try:
             balena_supervisor = BalenaSupervisor.new_from_env()
-            device_status = balena_supervisor.get_device_status()
+            device_status = balena_supervisor.get_device_status('appState')
 
-            if device_status == 'success':
+            if device_status == 'applied':
                 diagnostics_report.record_result("device_ready", self)
             else:
-                diagnostics_report.record_failure(device_status, self)
+                diagnostics_report.record_failure(f"appState is {device_status}", self)
 
         except Exception as e:
-            diagnostics_report.record_failure(str(e), self)
+            diagnostics_report.record_failure(e, self)

--- a/hw_diag/tests/diagnostics/test_device_status_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_device_status_diagnostic.py
@@ -1,0 +1,44 @@
+import unittest
+from unittest.mock import patch
+
+from hm_pyhelper.diagnostics.diagnostics_report import \
+    DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+from hw_diag.diagnostics.device_status_diagnostic import DeviceStatusDiagnostic
+
+
+class MockBalenaSupervisor:
+    def __init__(self, status_return_value) -> None:
+        self.status_return_value = status_return_value
+
+    def get_device_status(self, key):
+        return self.status_return_value
+
+
+class TestDeviceStatusDiagnostic(unittest.TestCase):
+    @patch(
+      "hw_diag.diagnostics.device_status_diagnostic.BalenaSupervisor.new_from_env",
+      return_value=MockBalenaSupervisor('applied'))
+    def test_success(self, mock):
+        diagnostic = DeviceStatusDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'device_status': 'device_ready'
+        })
+
+    @patch(
+      "hw_diag.diagnostics.device_status_diagnostic.BalenaSupervisor.new_from_env",
+      return_value=MockBalenaSupervisor('applying'))
+    def test_failure(self, mock):
+        diagnostic = DeviceStatusDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['device_status', 'device_status'],
+            'device_status': 'appState is applying'
+        })

--- a/hw_diag/utilities/balena_supervisor.py
+++ b/hw_diag/utilities/balena_supervisor.py
@@ -4,7 +4,7 @@ from requests.exceptions import ConnectionError, ConnectTimeout
 
 from hm_pyhelper.logger import get_logger
 
-log = get_logger(__name__)
+LOGGER = get_logger(__name__)
 
 
 class BalenaSupervisor:
@@ -26,33 +26,34 @@ class BalenaSupervisor:
             return requests.request(method=http_method, url=url, headers=self.headers)
 
         except (ConnectionError, ConnectTimeout) as requests_exception:
-            log.error(f"Connection error while trying to shutdown device. URL: {url}")
+            LOGGER.error(f"Connection error while trying to shutdown device. URL: {url}")
 
-            log.error(requests_exception)
+            LOGGER.error(requests_exception)
 
         except Exception as exp:
-            log.error(f"Error while trying to shutdown device. URL: {url}")
-            log.error(exp)
+            LOGGER.error(f"Error while trying to shutdown device. URL: {url}")
+            LOGGER.error(exp)
 
         return None
 
     def shutdown(self):
-        "Attempt device shutdown using balena supervisor API."
-        log.info("Attempting device shutdown using Balena supervisor.")
+        """Attempt device shutdown using balena supervisor API."""
+        LOGGER.info("Attempting device shutdown using Balena supervisor.")
 
         response = self._make_request('POST', '/v1/shutdown')
         if response is None or response.ok is False:
-            log.error("Device shutdown attempt failed.")
+            LOGGER.error("Device shutdown attempt failed.")
 
         return response.json()
 
-    def get_device_status(self) -> str:
-        "Get device status from balena supervisor API."
-        log.info("Attempting device shutdown using Balena supervisor.")
+    def get_device_status(self, key_to_return) -> str:
+        """Get device status from balena supervisor API."""
+        LOGGER.info("Retrieving device status using Balena supervisor.")
 
         response = self._make_request('GET', '/v2/state/status')
+        LOGGER.info(response.json())
         if response is None or response.ok is False:
-            log.error("Device status request failed.")
-            return ''
+            LOGGER.error("Device status request failed.")
+            raise Exception("Device status request failed")
 
-        return response.json().get('status', 'unknown')
+        return response.json()[key_to_return]

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -166,8 +166,18 @@ def add_gateway_txn():
 @DIAGNOSTICS.route('/v1/shutdown-gateway', methods=['POST'])
 def shutdown_gateway():
     """
-    Generates an add_gateway_txn if a destination name and wallets are defined and valid.
-    Diagnostics report will be in the format below if successful.
+    Shuts down the gateway using the Balena supervisor API.
+    Requires a signed PGP payload to be supplied in the format:
+
+    -----BEGIN PGP SIGNED MESSAGE-----
+    Hash: SHA256
+
+    {
+    "shutdown_gateway": true
+    }
+    -----BEGIN PGP SIGNATURE-----
+    [REDACTED]
+    -----END PGP SIGNATURE-----
 
     """
 


### PR DESCRIPTION
Testing, will convert to real PR when done.

**Issue**

- Link: https://github.com/NebraLtd/hm-diag/issues/335
- Summary: Was previously checking the wrong key in the status payload.

**How**
Use `appState` nstead of the `status` field, as instructed by Balena.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [x] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [x] Thought about variable and method names

