### PR TITLE
Light miner: Diagnostics page should NOT display local blockchain details #321

### DIFF
--- a/hw_diag/diagnostics/gateway_diagnostics.py
+++ b/hw_diag/diagnostics/gateway_diagnostics.py
@@ -1,0 +1,105 @@
+from hm_pyhelper.diagnostics import DiagnosticsReport
+from hm_pyhelper.diagnostics.diagnostic import Diagnostic
+from hm_pyhelper.gateway_grpc.client import GatewayClient, decode_pub_key
+from hm_pyhelper.miner_param import LOGGER
+from hm_pyhelper.constants import diagnostics as DIAG_CONSTS
+import grpc
+
+
+class DiagnosticKeyInfo:
+    def __init__(self, friendly_name: str, short_key: str = None,
+                 grpc_method_name: str = None,
+                 composed_attribute_path: str = None):
+        """"
+        Represents a Gateway Diagnostic key required to fetch
+        corresponding value.
+        composed_attribute_path represents the path inside the value returned
+        by grpc call represented by grpc_method_name
+        if short_key is not supplied it defaults to friendly_name
+        """
+        self.friendly_name = friendly_name
+        self.short_key = short_key
+        if short_key is None:
+            self.short_key = friendly_name
+        self.grpc_method_name = grpc_method_name
+        self.composed_attribute_path = composed_attribute_path
+
+
+class GatewayDiagnostic(Diagnostic):
+    def __init__(self, keyinfo: DiagnosticKeyInfo):
+        super(GatewayDiagnostic, self).__init__(keyinfo.short_key, keyinfo.friendly_name)
+        self.keyinfo = keyinfo
+
+    def call_grpc(self, diagnostics_report: DiagnosticsReport,
+                  method_name: str, *args, **kwargs) -> object:
+        """
+        returns grpc return value if successful, None otherwise
+        """
+        try:
+            with GatewayClient() as client:
+                return getattr(client, method_name)(*args, **kwargs)
+        except grpc.RpcError as err:
+            LOGGER.error(f"rpc error: {err}")
+            LOGGER.exception(err)
+            diagnostics_report.record_failure(err, self)
+        except Exception as err:
+            LOGGER.exception(err)
+            diagnostics_report.record_failure(err, self)
+        return None
+
+    def perform_test(self, diagnostics_report):
+        ret_value = self.call_grpc(diagnostics_report,
+                                   self.keyinfo.grpc_method_name)
+
+        # if grpc has failed
+        if not ret_value:
+            return
+
+        # return simple value
+        if not self.keyinfo.composed_attribute_path:
+            diagnostics_report.record_result(ret_value, self)
+            return
+
+        # flatten the composite value
+        try:
+            for attribute_name in self.keyinfo.composed_attribute_path.split('.'):
+                ret_value = getattr(ret_value, attribute_name)
+            # this key requires additional decoding
+            if self.keyinfo.friendly_name == DIAG_CONSTS.VALIDATOR_ADDRESS_KEY:
+                ret_value = decode_pub_key(ret_value)
+            diagnostics_report.record_result(ret_value, self)
+        except Exception as err:
+            diagnostics_report.record_failure(err, self)
+
+
+class GatewayDiagnostics(Diagnostic):
+
+    SUPPORTED_GATEWAY_ATTRIBUTES = [
+        DiagnosticKeyInfo(friendly_name=DIAG_CONSTS.VALIDATOR_ADDRESS_KEY,
+                          grpc_method_name='get_validator_info',
+                          composed_attribute_path='gateway.address'),
+        DiagnosticKeyInfo(friendly_name=DIAG_CONSTS.VALIDATOR_URI_KEY,
+                          grpc_method_name='get_validator_info',
+                          composed_attribute_path='gateway.uri'),
+        DiagnosticKeyInfo(friendly_name=DIAG_CONSTS.VALIDATOR_BLOCK_AGE,
+                          grpc_method_name='get_validator_info',
+                          composed_attribute_path='block_age'),
+        DiagnosticKeyInfo(friendly_name=DIAG_CONSTS.VALIDATOR_BLOCK_HEIGHT_KEY,
+                          short_key=DIAG_CONSTS.VALIDATOR_BLOCK_HEIGHT_SHORT_KEY,
+                          grpc_method_name='get_validator_info',
+                          composed_attribute_path='height'),
+        DiagnosticKeyInfo(friendly_name=DIAG_CONSTS.GATEWAY_PUBKEY_KEY,
+                          grpc_method_name='get_pubkey'),
+        DiagnosticKeyInfo(friendly_name=DIAG_CONSTS.GATEWAY_REGION_KEY,
+                          short_key=DIAG_CONSTS.GATEWAY_REGION_SHORT_KEY,
+                          grpc_method_name='get_region'),
+    ]
+
+    def __init__(self):
+        self.gateway_diagnostics = []
+        for attribute in self.SUPPORTED_GATEWAY_ATTRIBUTES:
+            self.gateway_diagnostics.append(GatewayDiagnostic(attribute))
+
+    def perform_test(self, diagnostics_report: DiagnosticsReport) -> None:
+        for diagnostic in self.gateway_diagnostics:
+            diagnostic.perform_test(diagnostics_report)

--- a/hw_diag/tasks.py
+++ b/hw_diag/tasks.py
@@ -4,17 +4,15 @@ import json
 
 from hm_pyhelper.hardware_definitions import variant_definitions
 from hm_pyhelper.miner_param import get_ethernet_addresses
-from hw_diag.utilities.blockchain import get_helium_blockchain_height
 from hw_diag.utilities.hardware import detect_ecc
 from hw_diag.utilities.hardware import get_serial_number
 from hw_diag.utilities.hardware import lora_module_test
 from hw_diag.utilities.hardware import set_diagnostics_bt_lte
 from hw_diag.utilities.hardware import get_public_keys_and_ignore_errors
-from hw_diag.utilities.miner import fetch_miner_data
 from hw_diag.utilities.shell import get_environment_var
 from hw_diag.utilities.gcs_shipper import upload_diagnostics
-from hm_pyhelper.miner_json_rpc.exceptions import MinerFailedFetchData
-from requests.exceptions import ConnectTimeout, ReadTimeout
+from hw_diag.diagnostics.gateway_diagnostics import GatewayDiagnostics
+from hm_pyhelper.diagnostics import DiagnosticsReport
 
 
 log = logging.getLogger()
@@ -24,7 +22,14 @@ log.setLevel(logging.DEBUG)
 def perform_hw_diagnostics(ship=False):  # noqa: C901
     log.info('Running periodic hardware diagnostics')
 
-    diagnostics = {}
+    diagnostics = [
+        GatewayDiagnostics()
+    ]
+
+    diagnostics_report = DiagnosticsReport(diagnostics)
+    diagnostics_report.perform_diagnostics()
+
+    diagnostics = diagnostics_report
 
     now = datetime.datetime.utcnow()
     diagnostics['last_updated'] = now.strftime("%H:%M UTC %d %b %Y")
@@ -40,55 +45,7 @@ def perform_hw_diagnostics(ship=False):  # noqa: C901
     diagnostics['PK'] = public_keys['key']
     diagnostics['AN'] = public_keys['name']
 
-    # Fetch data from miner container.
-    try:
-        diagnostics = fetch_miner_data(diagnostics)
-    except MinerFailedFetchData as e:
-        log.exception(e)
-    except Exception as e:
-        log.exception(e)
-
-    # Get the blockchain height from the Helium API
-    value = None
-    try:
-        value = get_helium_blockchain_height()
-    except KeyError as e:
-        logging.warning(e)
-    except (ConnectTimeout, ReadTimeout):
-        err_str = ("Request to Helium API timed out."
-                   " Will fallback to block height of 1.")
-        logging.exception(err_str)
-    diagnostics['BCH'] = value
-
-    # Check if the miner height
-    # is within 500 blocks and if so say it's synced
-    if diagnostics['BCH'] is None or diagnostics['MH'] is None:
-        diagnostics['MS'] = False
-    elif int(diagnostics['MH']) > (int(diagnostics['BCH']) - 500):
-        diagnostics['MS'] = True
-    else:
-        diagnostics['MS'] = False
-
-    # Calculate a percentage for block sync
-    if diagnostics['BCH'] is None or diagnostics['MH'] is None:
-        diagnostics['BSP'] = None
-    else:
-        diag_mh = int(diagnostics['MH'])
-        diag_bch = int(diagnostics['BCH'])
-        diagnostics['BSP'] = round(diag_mh / diag_bch * 100, 3)
-
     set_diagnostics_bt_lte(diagnostics)
-
-    # Check if the region has been set
-    try:
-        with open("/var/pktfwd/region", 'r') as data:
-            region = data.read()
-            if len(region) > 3:
-                log.info("Frequency: " + str(region))
-                diagnostics['RE'] = str(region).rstrip('\n')
-    except FileNotFoundError:
-        # No region found, put a dummy region in
-        diagnostics['RE'] = "UN123"
 
     # Check the basics if they're fine and set an overall value
     # Basics are: ECC valid, Mac addresses aren't FF, BT Is present,
@@ -97,7 +54,9 @@ def perform_hw_diagnostics(ship=False):  # noqa: C901
             diagnostics["ECC"] is True
             and diagnostics["E0"] is not None
             and diagnostics["W0"] is not None
-            and diagnostics["BT"] is True and diagnostics["LOR"] is True
+            and diagnostics["BT"] is True
+            and diagnostics["LOR"] is True
+            and not diagnostics.has_errors(["validator_uri"])
     ):
         diagnostics["PF"] = True
     else:

--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -57,32 +57,6 @@
                   {% endif %}
                 </tr>
                 <tr>
-                  <td>Sync Percentage</td>
-                  {% if not diagnostics.BCH and not diagnostics.MH %}
-                    <td class="text-right">Helium API and Miner RPC Unavailable</td>
-                  {% elif not diagnostics.BCH %}
-                    <td class="text-right">Helium API Unavailable</td>
-                  {% elif not diagnostics.MH %}
-                    <td class="text-right">Miner RPC Unavailable</td>
-                  {% elif diagnostics.BSP > 99.98 %}
-                    <td class="text-right">100%</td>
-                  {% else %}
-                    <td class="text-right">{{ '%0.2f' % diagnostics.BSP|float }}%</td>
-                  {% endif %}
-                </tr>
-                <tr>
-                  <td>Height Status</td>
-                  {% if not diagnostics.BCH and not diagnostics.MH %}
-                    <td class="text-right">Helium API and Miner RPC Unavailable</td>
-                  {% elif not diagnostics.BCH %}
-                    <td class="text-right">Helium API Unavailable</td>
-                  {% elif not diagnostics.MH %}
-                    <td class="text-right">Miner RPC Unavailable</td>
-                  {% else %}
-                    <td class="text-right">{{ diagnostics.MH }} / {{ diagnostics.BCH }}</td>
-                  {% endif %}
-                </tr>
-                <tr>
                   <td>Firmware Version</td>
                   <td class="text-right">{{ diagnostics.FW }} ({{ diagnostics.firmware_short_hash }})</td>
                 </tr>
@@ -92,10 +66,10 @@
                 </tr>
                 <tr>
                   <td>Region Plan</td>
-                  {% if diagnostics.RE == 'UN123' %}
-                    <td class="text-right">Awaiting Location Assertion</td>
+                  {% if not diagnostics.has_errors([DIAG_CONSTS.GATEWAY_REGION_KEY]) %}
+                    <td class="text-right">{{ diagnostics.get(DIAG_CONSTS.GATEWAY_REGION_KEY) }}</td>
                   {% else %}
-                    <td class="text-right">{{ diagnostics.RE }}</td>
+                    <td class="text-right">Unknown Location</td>
                   {% endif %}
                 </tr>
                 <tr>
@@ -103,12 +77,28 @@
                   <td class="text-right">{{ diagnostics.FRIENDLY }}</td>
                 </tr>
                 <tr>
-                  <td>Miner Connected To Blockchain</td>
-                  {% if diagnostics.MC %}
-                    <td class="text-success text-right">True</td>
+                  <td>Connected Validator</td>
+                  {% if not diagnostics.has_errors([DIAG_CONSTS.VALIDATOR_URI_KEY]) %}
+                    <td class="text-success text-right">{{ diagnostics.get(DIAG_CONSTS.VALIDATOR_URI_KEY) }} </td>
                   {% else %}
-                    <td class="text-warning text-right">False</td>
+                    <td class="text-warning text-right">Disconnected</td>
                   {% endif %}
+                </tr>
+                <tr>
+                    <td>Validator Block Height</td>
+                    {% if not diagnostics.has_errors([DIAG_CONSTS.VALIDATOR_BLOCK_HEIGHT_KEY]) %}
+                        <td class="text-success text-right">{{ diagnostics.get(DIAG_CONSTS.VALIDATOR_BLOCK_HEIGHT_KEY) }}</td>
+                    {% else %}
+                        <td class="text-warning text-right">Disconnected</td>
+                    {% endif %}
+                  </tr>
+                <tr>
+                    <td>Validator Block Age</td>
+                    {% if not diagnostics.has_errors([DIAG_CONSTS.VALIDATOR_BLOCK_AGE]) %}
+                      <td class="text-success text-right">{{ diagnostics.get(DIAG_CONSTS.VALIDATOR_BLOCK_AGE) }} </td>
+                    {% else %}
+                      <td class="text-warning text-right">Disconnected</td>
+                    {% endif %}
                 </tr>
               </table>
             </div>
@@ -116,14 +106,6 @@
           <div class="col-12 col-lg-6 mb-4 mb-lg-0">
             <div class="card mb-0 h-100">
               <table class="table dt-responsive nowrap m-2 w-auto">
-                <tr>
-                  <td class="border-0">Miner Relayed</td>
-                  {% if diagnostics.MN == 'symmetric' %}
-                    <td class="border-0 text-warning text-right">True</td>
-                  {% else %}
-                    <td class="border-0 text-success text-right">False</td>
-                  {% endif %}
-                </tr>
                 <tr>
                   <td>ECC Detected</td>
                   {% if diagnostics.ECC %}

--- a/hw_diag/tests/diagnostics/test_add_gateway_txn_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_add_gateway_txn_diagnostic.py
@@ -6,7 +6,7 @@ import hm_pyhelper
 from hm_pyhelper.constants.shipping import DESTINATION_ADD_GATEWAY_TXN_KEY
 from hm_pyhelper.diagnostics.diagnostics_report import \
     DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
-from hm_pyhelper.miner_json_rpc.exceptions import MinerMalformedAddGatewayTxn
+from hm_pyhelper.gateway_grpc.exceptions import MinerMalformedAddGatewayTxn
 
 from hw_diag.diagnostics.add_gateway_txn_diagnostic import AddGatewayTxnDiagnostic
 from hw_diag.utilities.security import GnuPG
@@ -68,7 +68,7 @@ bsoB7mtn
     def tearDownClass(cls):
         cls.gnupg.cleanup()
 
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'create_add_gateway_txn',
+    @patch.object(hm_pyhelper.gateway_grpc.client.GatewayClient, 'create_add_gateway_txn',
                   return_value=mocked_create_add_gateway_txn_result)
     def test_success(self, mock):
         diagnostics = [
@@ -90,7 +90,7 @@ bsoB7mtn
             },
         })
 
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'create_add_gateway_txn',
+    @patch.object(hm_pyhelper.gateway_grpc.client.GatewayClient, 'create_add_gateway_txn',
                   return_value=mocked_create_add_gateway_txn_result)
     def test_failure_invalid_signature(self, mock):
         shipping_destination_json_with_invalid_signature = b"""
@@ -112,7 +112,7 @@ bsoB7mtn
             DESTINATION_ADD_GATEWAY_TXN_KEY: 'Verifying the payload PGP signature failed.',
         })
 
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'create_add_gateway_txn',
+    @patch.object(hm_pyhelper.gateway_grpc.client.GatewayClient, 'create_add_gateway_txn',
                   side_effect=MinerMalformedAddGatewayTxn('Address is incorrect.'))
     def test_failure_txn_exception(self, mock):
         diagnostics = [

--- a/hw_diag/tests/test_get_miner_diag.py
+++ b/hw_diag/tests/test_get_miner_diag.py
@@ -1,78 +1,43 @@
 import unittest
-
 from unittest.mock import patch
-from copy import deepcopy
+import grpc
+from concurrent import futures
 
-import hm_pyhelper.miner_json_rpc.client
-
-from hw_diag.utilities.miner import fetch_miner_data
+import hm_pyhelper
+from hm_pyhelper.protos import local_pb2_grpc
+from hm_pyhelper.tests.test_gateway_grpc import TestData, MockServicer
+from hw_diag.diagnostics.gateway_diagnostics import GatewayDiagnostics
+from hm_pyhelper.diagnostics import DiagnosticsReport
+from hm_pyhelper.constants import diagnostics as DIAG_CONSTS
 
 
 class TestGetMinerDiag(unittest.TestCase):
-    PEER_ADDR = {
-        'peer_addr':
-            '/p2p/11rMJrFystAT3mLEdgeeVo2opSmHuMb2RXFVYh7qfqhqt2GkPv9'
-    }
 
-    HEIGHT = {'height': 1045324}
+    def start_mock_server(self):
+        self.mock_server = grpc.server(futures.ThreadPoolExecutor(max_workers=10))
+        local_pb2_grpc.add_apiServicer_to_server(MockServicer(), self.mock_server)
+        self.mock_server.add_insecure_port(f'[::]:{TestData.server_port}')
+        self.mock_server.start()
 
-    PEER_BOOK = [
-        {
-            'connection_count': 5,
-            'listen_addr_count': 1,
-            'name': 'wild-purple-tuna',
-            'nat': 'static'
-        }
-    ]
+    def test_gateway_diagnostic(self):
+        with patch.object(hm_pyhelper.gateway_grpc.client.GatewayClient.__init__,
+                          '__defaults__', (f"localhost:{TestData.server_port}",)):
+            self.start_mock_server()
+            diagnostics = [
+                GatewayDiagnostics()
+            ]
 
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'get_peer_addr', return_value=PEER_ADDR)
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'get_peer_book',
-                  return_value=deepcopy(PEER_BOOK))
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'get_height', return_value=HEIGHT)
-    def test_fetch_miner_data_valid(self, mock_height, mock_book, mock_addr):
-        expected_data = {
-            'MC': True,
-            'MD': True,
-            'MH': 1045324,
-            'MN': 'static',
-            'MR': False
-        }
-
-        result = fetch_miner_data({})
-        self.assertEqual(result, expected_data)
-
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'get_peer_addr', return_value=PEER_ADDR)
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'get_peer_book',
-                  return_value=deepcopy(PEER_BOOK))
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'get_height', return_value=HEIGHT)
-    def test_fetch_miner_data_relayed(self, mock_height, mock_book, mock_addr):
-        mock_book.return_value[0]['nat'] = 'symmetric'
-
-        expected_data = {
-            'MC': True,
-            'MD': True,
-            'MH': 1045324,
-            'MN': 'symmetric',
-            'MR': True
-        }
-
-        result = fetch_miner_data({})
-        self.assertEqual(result, expected_data)
-
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'get_peer_addr', return_value=PEER_ADDR)
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'get_peer_book',
-                  return_value=deepcopy(PEER_BOOK))
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'get_height', return_value=HEIGHT)
-    def test_fetch_miner_data_not_connected(self, mock_height, mock_book, mock_addr):
-        mock_book.return_value[0]['connection_count'] = 0
-
-        expected_data = {
-            'MC': False,
-            'MD': True,
-            'MH': 1045324,
-            'MN': 'static',
-            'MR': False
-        }
-
-        result = fetch_miner_data({})
-        self.assertEqual(result, expected_data)
+            diagnostics_report = DiagnosticsReport(diagnostics)
+            diagnostics_report.perform_diagnostics()
+            expected_data = {
+                DIAG_CONSTS.VALIDATOR_ADDRESS_KEY: TestData.validator_address_decoded,
+                DIAG_CONSTS.VALIDATOR_URI_KEY: TestData.height_res.gateway.uri,
+                DIAG_CONSTS.VALIDATOR_BLOCK_AGE: TestData.height_res.block_age,
+                DIAG_CONSTS.VALIDATOR_BLOCK_HEIGHT_KEY: TestData.height_res.height,
+                DIAG_CONSTS.VALIDATOR_BLOCK_HEIGHT_SHORT_KEY: TestData.height_res.height,
+                DIAG_CONSTS.GATEWAY_REGION_KEY: TestData.region_name,
+                DIAG_CONSTS.GATEWAY_REGION_SHORT_KEY: TestData.region_name,
+                DIAG_CONSTS.GATEWAY_PUBKEY_KEY: TestData.pubkey_decoded
+            }
+            self.assertDictContainsSubset(expected_data, diagnostics_report)
+            self.mock_server.stop(grace=0)

--- a/hw_diag/tests/test_views_diagnostics.py
+++ b/hw_diag/tests/test_views_diagnostics.py
@@ -50,7 +50,8 @@ class TestGetDiagnostics(unittest.TestCase):
             self.assertEqual(resp.status_code, 200)
             self.assertEqual(resp.status, '200 OK')
 
-    def test_get_json_output(self):
+    @patch('hm_pyhelper.miner_param.get_mac_address', return_value='A0:32:23:B4:C5:D6')
+    def test_get_json_output(self, mock_get_mac_address):
         # Check the diagnostics JSON output.
         url = '/json'
         # Server perspective
@@ -159,7 +160,7 @@ bsoB7mtn
         "txn": "CrkBCiEBrlImpYLbJ0z0hw5b4g9isRyPrgbXs9X+RrJ4pJJc9MkS..."
     }
 
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'create_add_gateway_txn',
+    @patch.object(hm_pyhelper.gateway_grpc.client.GatewayClient, 'create_add_gateway_txn',
                   return_value=mocked_create_add_gateway_txn_result)
     @patch('hw_diag.views.diagnostics.GnuPG')
     def test_add_gateway_txn_success(self, mock_gnupg, mock_txn):
@@ -176,7 +177,7 @@ bsoB7mtn
             DESTINATION_ADD_GATEWAY_TXN_KEY: self.mocked_create_add_gateway_txn_result,
         })
 
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'create_add_gateway_txn',
+    @patch.object(hm_pyhelper.gateway_grpc.client.GatewayClient, 'create_add_gateway_txn',
                   return_value=mocked_create_add_gateway_txn_result)
     @patch('hw_diag.views.diagnostics.GnuPG')
     def test_add_gateway_txn_failure_no_payload(self, mock_gnupg, mock_txn):
@@ -193,7 +194,7 @@ bsoB7mtn
             DESTINATION_ADD_GATEWAY_TXN_KEY: 'Can not find payload.',
         })
 
-    @patch.object(hm_pyhelper.miner_json_rpc.client.Client, 'create_add_gateway_txn',
+    @patch.object(hm_pyhelper.gateway_grpc.client.GatewayClient, 'create_add_gateway_txn',
                   return_value=mocked_create_add_gateway_txn_result)
     @patch('hw_diag.views.diagnostics.GnuPG')
     def test_add_gateway_txn_failure_invalid_signature(self, mock_gnupg, mock_txn):

--- a/hw_diag/utilities/miner.py
+++ b/hw_diag/utilities/miner.py
@@ -1,40 +1,9 @@
 from hm_pyhelper.constants.nebra import NEBRA_WALLET_ADDRESS
-from hm_pyhelper.miner_json_rpc import MinerClient
-from hm_pyhelper.miner_json_rpc.exceptions import MinerFailedFetchData
-from hm_pyhelper.miner_param import LOGGER
+from hm_pyhelper.gateway_grpc.client import GatewayClient
 
 
-def fetch_miner_data(diagnostics):
-    client = MinerClient()
-    try:
-        peerbook = client.get_peer_book()[0]
-        height = client.get_height()
-    except MinerFailedFetchData as err:
-        LOGGER.exception(err)
-        diagnostics['MC'] = "Failed to Fetch"
-        diagnostics['MD'] = "Failed to Fetch"
-        diagnostics['MH'] = None
-        diagnostics['MN'] = "Failed to Fetch"
-        diagnostics['MR'] = "Failed to Fetch"
-        return diagnostics
-    except Exception as err:
-        LOGGER.exception(err)
-        diagnostics['MC'] = "Failed to Fetch"
-        diagnostics['MD'] = "Failed to Fetch"
-        diagnostics['MH'] = None
-        diagnostics['MN'] = "Failed to Fetch"
-        diagnostics['MR'] = "Failed to Fetch"
-        return diagnostics
-
-    diagnostics['MC'] = peerbook.get('connection_count') > 1
-    diagnostics['MD'] = peerbook.get('listen_addr_count') > 0
-    diagnostics['MH'] = height.get('height')
-    diagnostics['MN'] = peerbook.get('nat')
-    diagnostics['MR'] = diagnostics['MN'] == 'symmetric'
-    return diagnostics
-
-
-def create_add_gateway_txn(destination_wallet):
-    client = MinerClient()
-    add_gateway_txn = client.create_add_gateway_txn(destination_wallet, NEBRA_WALLET_ADDRESS)
-    return add_gateway_txn
+def create_add_gateway_txn(destination_wallet: str) -> dict:
+    with GatewayClient() as client:
+        add_gateway_txn = client.create_add_gateway_txn(destination_wallet,
+                                                        NEBRA_WALLET_ADDRESS)
+        return add_gateway_txn

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -2,6 +2,7 @@ import json
 import base64
 import os
 import logging
+import traceback
 
 from flask import Blueprint, request
 from flask import render_template
@@ -28,7 +29,7 @@ from hw_diag.utilities.hardware import should_display_lte
 from hw_diag.tasks import perform_hw_diagnostics
 from hm_pyhelper.logger import get_logger
 from hw_diag.utilities.security import GnuPG
-
+from hm_pyhelper.constants import diagnostics as DIAG_CONSTS
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "DEBUG"))
 
 LOGGER = get_logger(__name__)
@@ -47,6 +48,7 @@ def read_diagnostics_file():
         diagnostics = {'error': msg}
     except Exception as e:
         msg = 'Diagnostics has encountered an error: %s'
+        traceback.format_exc()
         diagnostics = {'error': msg % str(e)}
 
     return diagnostics
@@ -67,13 +69,15 @@ def get_diagnostics_json():
 @cache.cached(timeout=60)
 def get_diagnostics():
     diagnostics = read_diagnostics_file()
+    diag_report = DiagnosticsReport.from_json_dict(diagnostics)
     display_lte = should_display_lte(diagnostics)
     now = datetime.utcnow()
 
     return render_template(
         'diagnostics_page.html',
-        diagnostics=diagnostics,
+        diagnostics=diag_report.from_json_dict(diagnostics),
         display_lte=display_lte,
+        DIAG_CONSTS=DIAG_CONSTS,
         now=now
     )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,9 @@
 werkzeug==2.0.3
 Flask-APScheduler==1.12.3
+grpcio==1.44.0
 Flask-Caching==1.10.1
 Flask==2.0.1
+werkzeug==2.0.3
 certifi==2021.5.30
 click==7.1.2
 gunicorn==20.1.0
@@ -9,5 +11,5 @@ requests==2.26.0
 retry==0.9.2
 sentry-sdk[Flask]==1.5.1
 dbus-python==1.2.16
-hm-pyhelper==0.13.16
+hm-pyhelper @ https://github.com/NebraLtd/hm-pyhelper/archive/74beabb.zip
 python-gnupg==0.4.8


### PR DESCRIPTION
**[#321](https://github.com/NebraLtd/hm-diag/issues/321)**

- Link: https://github.com/NebraLtd/hm-diag/issues/321
- Summary: remove local blockchain details and add validator blockchain details.

**How**
- Uses grpc to talk to locally running gateway-rs
- displays validator information in diag page. Shows "disconnected" when it can't connect to validator

**Screenshots**
![diag_lighthotspot](https://user-images.githubusercontent.com/6928727/163998800-58e40d38-3422-4b21-a021-1552588685b9.png)
![diag_working](https://user-images.githubusercontent.com/6928727/165319638-f9605392-beeb-456a-bd7d-40447afab7e2.png)




**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [x] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

