### PR TITLE
feat: virtual env and caching in dockerfile #327

### DIFF
--- a/.github/workflows/compile-docker.yml
+++ b/.github/workflows/compile-docker.yml
@@ -48,6 +48,8 @@ jobs:
           push: true
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=registry,ref=nebraltd/hm-diag:buildcache
+          cache-to: type=registry,ref=nebraltd/hm-diag:buildcache,mode=max
 
       - name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,47 +3,59 @@
 ####################################################################################################
 ################################## Stage: builder ##################################################
 
-FROM balenalib/raspberry-pi-debian-python:buster-run-20211014 as builder
+FROM balenalib/raspberry-pi-debian:buster-build-20211014 as builder
 
-ENV PYTHON_DEPENDENCIES_DIR=/opt/python-dependencies
+# Nebra uses /opt by convention
+WORKDIR /opt/
 
-RUN mkdir /tmp/build
-COPY ./ /tmp/build
-WORKDIR /tmp/build
-
-
-
+# this installs python 3.7.3 which is buster default and supported by grpcio wheel
 RUN \
     install_packages \
-            build-essential \
-            libdbus-glib-1-dev
+        python3-minimal \
+        python3-venv \
+        python3-pip \
+        build-essential \
+        libdbus-glib-1-dev
 
-RUN pip3 install --no-cache-dir --target="$PYTHON_DEPENDENCIES_DIR" .
+# This will be the path that venv uses for installation below
+ENV PATH="/opt/venv/bin:$PATH"
+
+# without pinning the pip version, we get linter warning
+COPY requirements.txt requirements.txt
+RUN python3 -m venv /opt/venv && \
+    pip install --no-cache-dir --upgrade pip==22.0.1 && \
+    pip install --no-cache-dir -r requirements.txt
 
 # firehose build, the tar is obtained from  quectel.
 # there is no install target in Makefile, doing manual copy
-RUN tar -xf quectel/qfirehose/QFirehose_Linux_Android_V1.4.9.tar
+COPY quectel quectel
+RUN tar -xf ./quectel/qfirehose/QFirehose_Linux_Android_V1.4.9.tar
 # docker linter wants WORKDIR for changing directory
-WORKDIR /tmp/build/QFirehose_Linux_Android_V1.4.9
+WORKDIR /opt/QFirehose_Linux_Android_V1.4.9
 RUN make && \
     cp QFirehose /usr/sbin/QFirehose && \
     rm -rf quectel/qfirehose
+
+WORKDIR /opt
+COPY ./ /opt
+RUN pip --no-cache-dir install .
 
 # No need to cleanup the builder
 
 ####################################################################################################
 ################################### Stage: runner ##################################################
 
-FROM balenalib/raspberry-pi-debian-python:buster-run-20211014 as runner
-
-ENV PYTHON_DEPENDENCIES_DIR=/opt/python-dependencies
+FROM balenalib/raspberry-pi-debian-python:buster-build-20211014 as runner
 
 RUN \
     install_packages \
+        python3-minimal \
+        python3-venv \
         wget \
         i2c-tools \
         libdbus-1-3 \
-        gpg
+        gpg \
+        libatomic1
 
 # Nebra uses /opt by convention
 WORKDIR /opt/
@@ -61,17 +73,17 @@ RUN rm manufacturing-key.gpg
 #    --retries=10 \
 #  CMD wget -q -O - http://0.0.0.0:5000/initFile.txt || exit 1
 
-# Copy packages from builder
-COPY --from=builder "$PYTHON_DEPENDENCIES_DIR" "$PYTHON_DEPENDENCIES_DIR"
+
+# copy python env
+COPY --from=builder /opt/venv /opt/venv
 
 # copy modem flashing tool
 COPY --from=builder /usr/sbin/QFirehose /usr/sbin/QFirehose
 
 # copy firmware files
-COPY --from=builder /tmp/build/quectel /quectel
+COPY --from=builder /opt/quectel /quectel
 
-# Add python dependencies to PYTHONPATH
-ENV PYTHONPATH="${PYTHON_DEPENDENCIES_DIR}:${PYTHONPATH}"
-ENV PATH="${PYTHON_DEPENDENCIES_DIR}/bin:${PATH}"
+# Add python venv path
+ENV PATH="/opt/venv/bin:$PATH"
 
 ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:5000", "--timeout", "300", "hw_diag:wsgi_app"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 Flask-APScheduler==1.12.2
 Flask-Caching==1.10.1
 Flask==2.0.1
+werkzeug==2.0.3
 certifi==2021.5.30
 click==7.1.2
 gunicorn==20.1.0
@@ -10,3 +11,4 @@ sentry-sdk[Flask]==1.5.1
 dbus-python==1.2.16
 hm-pyhelper==0.13.16
 python-gnupg==0.4.8
+grpcio==1.44.0


### PR DESCRIPTION
* use virtualenv with debian supplied python
* incorporate caching to and from dockerhub registry.

**[Issue](https://github.com/NebraLtd/hm-diag/issues/327)**

- Link: https://github.com/NebraLtd/hm-diag/issues/327
- Summary: add virtual env to have access to grpcio wheel and enable caching

**How**
- compile docker workflow was modified to push and pull buildcache from registry
- dockerfile was modified to:
  - make better use of build cache
  - use venv with debian supplied python version so that we can find grpcio wheel in pip

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

