### PR TITLE
fix: Add host networking to hm-miner to access grpc api #427

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -74,4 +74,4 @@ COPY --from=builder /tmp/build/quectel /quectel
 ENV PYTHONPATH="${PYTHON_DEPENDENCIES_DIR}:${PYTHONPATH}"
 ENV PATH="${PYTHON_DEPENDENCIES_DIR}/bin:${PATH}"
 
-ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:5000", "--timeout", "300", "hw_diag:wsgi_app"]
+ENTRYPOINT ["gunicorn", "--bind", "0.0.0.0:80", "--timeout", "300", "hw_diag:wsgi_app"]


### PR DESCRIPTION
**[Issue](https://github.com/NebraLtd/helium-miner-software/issues/427)**

- Link: https://github.com/NebraLtd/helium-miner-software/issues/427
- Summary: gateway-rs listens only on local host. Only way to make diag work at this stage is to use host networking. As we are now on host, we have to bind to port 80 for diagnostics to remain working

**How**
- bind diag http server to port 80

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [x] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names