### PR TITLE
Light hotspot: explorer link to connected validator #342

### DIFF
--- a/hw_diag/templates/diagnostics_page.html
+++ b/hw_diag/templates/diagnostics_page.html
@@ -79,7 +79,9 @@
                 <tr>
                   <td>Connected Validator</td>
                   {% if not diagnostics.has_errors([DIAG_CONSTS.VALIDATOR_URI_KEY]) %}
-                    <td class="text-success text-right">{{ diagnostics.get(DIAG_CONSTS.VALIDATOR_URI_KEY) }} </td>
+                    <!-- <td class="text-success text-right">{{ diagnostics.get(DIAG_CONSTS.VALIDATOR_URI_KEY) }} </td> -->
+                    <td class="border-0 text-success text-right"><a href="https://explorer.helium.com/validators/{{ diagnostics.get(DIAG_CONSTS.VALIDATOR_ADDRESS_KEY) }}"
+                        target="_blank">{{ diagnostics.get(DIAG_CONSTS.VALIDATOR_URI_KEY) }}</a></td>
                   {% else %}
                     <td class="text-warning text-right">Disconnected</td>
                   {% endif %}


### PR DESCRIPTION
* the validator ip has an embedded link to validator in explorer

**#342**

- Link: https://github.com/NebraLtd/hm-diag/issues/342
- Summary: feedback from support team that one should be able to inspect validator in exporer

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

