### PR TITLE
Consolidate diagnostics page changes for light hotspot activation #357

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,5 @@
 include hw_diag/templates/diagnostics_page.html
+include hw_diag/templates/diagnostics_page_light_miner.html
 include hw_diag/static/css/bootstrap.min.css
 include hw_diag/static/fonts/*.ttf
 include hw_diag/static/images/nebra-logo.svg

--- a/README.md
+++ b/README.md
@@ -102,3 +102,15 @@ This repo automatically builds docker containers and uploads them to two reposit
 - [hm-diag on GitHub Packages](https://github.com/NebraLtd/hm-diag/pkgs/container/hm-diag)
 
 The images are tagged using the docker long and short commit SHAs for that release. The current version deployed to miners can be found in the [helium-miner-software repo](https://github.com/NebraLtd/helium-miner-software/blob/production/docker-compose.yml).
+
+## Light hotspot notes
+Helium network is transitioning to light hotspot mode. During the transition, there is a possibility of hotspot going back and forth between light and full blockchain sync mode. We support a environment variable (DISPLAY_MINER_INFO) to disable showing blockchain mining information so that administrators can enable/disable its visibility to avoid confusion among their customers.
+
+The envvar default to true.
+If set and set to anything other than true, following mining information will be hidden:
+- Sync Percentage
+- Miner Connected To Blockchain
+- Height Status
+- Miner Relayed
+
+This is a temporary capability that will be removed when hotspots moves to gateway-rs. Instead validator information will be shown.

--- a/hw_diag/templates/diagnostics_page_light_miner.html
+++ b/hw_diag/templates/diagnostics_page_light_miner.html
@@ -1,0 +1,156 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta http-equiv="refresh" content="300">
+  <title>Nebra Hotspot Diagnostics</title>
+  <!-- Bootstrap core CSS -->
+  <link href="/static/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="shortcut icon" href="/static/images/favicon.ico">
+  <meta name="theme-color" content="#03a9f4">
+  <meta name="robots" content="noindex, nofollow">
+</head>
+<body>
+  <header class="bg-white mb-4 d-flex justify-content-center">
+    <a href="#" class="p-3 text-center">
+      <img src="/static/images/nebra-logo.svg"  height="32" alt="Nebra Logo" />
+    </a>
+  </header>
+  <section class="container pb-4">
+
+      {% if diagnostics.error %}
+        <div class="text-center pb-4 mb-4 border-bottom border-light">
+          <h1>Diagnostics Information</h1>
+          <br />
+          <h3>{{ diagnostics.error }}</h3>
+        </div>
+      {% else %}
+        <div class="text-center pb-4 mb-4 border-bottom border-light">
+            <h1>Diagnostics Information</h1>
+            <br />
+            <h3>
+              {% if not diagnostics.AN %}
+                Animal Name Unavailable
+              {% else %}
+                {{ diagnostics.AN }}
+              {% endif %}
+            </h3>
+            {% if diagnostics.PF %}
+                    <h3 class="text-success">All Ok</h3>
+            {% else %}
+                    <h3 class="text-danger">Errors Found</h3>
+            {% endif %}
+        </div>
+        <h3 class="text-center mb-4">Diagnostics Breakdown</h3>
+        <div class="row mb-4">
+          <div class="col-12 col-lg-6 mb-4 mb-lg-0">
+            <div class="card mb-0 h-100">
+              <table class="table dt-responsive nowrap m-2 w-auto">
+                <tr>
+                  {% if not diagnostics.PK %}
+                    <td class="border-0">Helium Address</td>
+                    <td class="border-0 text-right">Animal Name Unavailable</td>
+                  {% else %}
+                    <td class="border-0">Helium Address</td>
+                    <td class="border-0 text-right"><a href="https://explorer.helium.com/hotspots/{{ diagnostics.PK }}" target="_blank">View on Explorer</a></td>
+                  {% endif %}
+                </tr>
+                <tr>
+                  <td>Firmware Version</td>
+                  <td class="text-right">{{ diagnostics.FW }} ({{ diagnostics.firmware_short_hash }})</td>
+                </tr>
+                <tr>
+                  <td>Frequency</td>
+                  <td class="text-right">{{ diagnostics.FR }}</td>
+                </tr>
+                <tr>
+                  <td>Region Plan</td>
+                  {% if diagnostics.RE == 'UN123' %}
+                    <td class="text-right">Awaiting Location Assertion</td>
+                  {% else %}
+                    <td class="text-right">{{ diagnostics.RE }}</td>
+                  {% endif %}
+                </tr>
+                <tr>
+                  <td>Variant</td>
+                  <td class="text-right">{{ diagnostics.FRIENDLY }}</td>
+                </tr>
+                <tr>
+                    <td>LoRa Operational</td>
+                    {% if diagnostics.LOR %}
+                      <td class="text-success text-right">True</td>
+                    {% else %}
+                      <td class="text-danger text-right">False</td>
+                    {% endif %}
+                </tr>
+              </table>
+            </div>
+          </div>
+          <div class="col-12 col-lg-6 mb-4 mb-lg-0">
+            <div class="card mb-0 h-100">
+              <table class="table dt-responsive nowrap m-2 w-auto">
+                <tr>
+                  <td class="border-0">ECC Detected</td>
+                  {% if diagnostics.ECC %}
+                    <td class="border-0 text-success text-right">True</td>
+                  {% else %}
+                    <td class="border-0 text-danger text-right">False</td>
+                  {% endif %}
+                </tr>
+                <tr>
+                  <td>Ethernet MAC Address</td>
+                  {% if diagnostics.E0 %}
+                  <td class="text-right">{{ diagnostics.E0 }}</td>
+                  {% else %}
+                    <td class="text-danger text-right">N/A</td>
+                  {% endif %}
+                </tr>
+                <tr>
+                  <td>WiFi MAC Address</td>
+                  {% if diagnostics.W0 %}
+                  <td class="text-right">{{ diagnostics.W0 }}</td>
+                  {% else %}
+                    <td class="text-danger text-right">N/A</td>
+                  {% endif %}
+                </tr>
+                <tr>
+                  <td>Hardware Serial Number</td>
+                  <td class="text-right">{{ diagnostics.serial_number }}</td>
+                </tr>
+                <tr>
+                  <td>Bluetooth Detected</td>
+                  {% if diagnostics.BT %}
+                    <td class="text-success text-right">True</td>
+                  {% else %}
+                    <td class="text-danger text-right">False</td>
+                  {% endif %}
+                </tr>
+                {% if display_lte  %}
+                  <tr>
+                    <td>Modem Detected</td>
+                    {% if diagnostics.LTE %}
+                      <td class="text-success text-right">True</td>
+                    {% else %}
+                      <td class="text-warning text-right">False</td>
+                    {% endif %}
+                  </tr>
+                {% endif %}
+              </table>
+            </div>
+          </div>
+        </div>
+      {% endif %}
+    <div class="text-center">
+      {% if diagnostics.last_updated %}
+        <p>Last Updated: {{ diagnostics.last_updated }}</p>
+      {% else %}
+        <p>Last Updated: Never</p>
+      {% endif %}
+      <p>To get support please visit <a href="https://nebra.io/helium-support">https://nebra.io/helium-support</a></p>
+      <p><a href="/json">Download Diagnostics Info for Support</a></p>
+      <p>&copy; Nebra LTD. 2020-{{ now.year }}<p>
+    </div>
+  </section>
+</body>
+</html>

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -69,9 +69,13 @@ def get_diagnostics():
     diagnostics = read_diagnostics_file()
     display_lte = should_display_lte(diagnostics)
     now = datetime.utcnow()
+    display_miner = os.getenv("DISPLAY_MINER_INFO", "true").lower() == "true"
+    template_filename = 'diagnostics_page_light_miner.html'
+    if display_miner:
+        template_filename = 'diagnostics_page.html'
 
     return render_template(
-        'diagnostics_page.html',
+        template_filename,
         diagnostics=diagnostics,
         display_lte=display_lte,
         now=now


### PR DESCRIPTION
**[Issue](https://github.com/NebraLtd/hm-diag/issues/357)**

- Link: https://github.com/NebraLtd/hm-diag/issues/357
- Summary: provide option to hide blockchain infrmation.

**How**
* introduced DISPLAY_MINER_INFO env vairable. It can be set to false to
hide display of miner info on diagnostic page.
* defaults to true

**Screenshots**
With Miner Info disabled:
![light_page](https://user-images.githubusercontent.com/6928727/167897170-c0298ba9-237e-4de1-9810-6bcc7c3a8694.png)

With Miner Info enabled:
![full_miner_page](https://user-images.githubusercontent.com/6928727/167897257-b06649f8-5565-4b1f-adc3-ee198478ed37.png)


**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [x] Documentation added
- [ ] Thought about variable and method names

