### PR TITLE
Update sentry config not to capture error level logging

### DIFF
--- a/hw_diag/app.py
+++ b/hw_diag/app.py
@@ -8,6 +8,7 @@ from datetime import timedelta
 from flask import Flask
 from flask_apscheduler import APScheduler
 from retry import retry
+from sentry_sdk.integrations.logging import LoggingIntegration
 
 from hw_diag.cache import cache
 from hw_diag.tasks import perform_hw_diagnostics
@@ -19,9 +20,15 @@ from sentry_sdk.integrations.flask import FlaskIntegration
 
 DIAGNOSTICS_VERSION = os.getenv('DIAGNOSTICS_VERSION')
 DSN_SENTRY = os.getenv('SENTRY_DIAG')
+
+sentry_logging = LoggingIntegration(
+    level=logging.CRITICAL,
+    event_level=logging.CRITICAL
+)
+
 sentry_sdk.init(
     dsn=DSN_SENTRY,
-    integrations=[FlaskIntegration()],
+    integrations=[sentry_logging, FlaskIntegration()],
     release=f"diagnostics@{DIAGNOSTICS_VERSION}",
 )
 


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-diag/issues/352
- Summary:
Should not generate sentry errors when `gateway_mfr` is exited with a non-zero status.

**How**
Update the sentry configuration so that error level logging shouldn't mess up the sentry issue and monthly quota.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

