### PR TITLE
Handle empty responses from Balena Supervisor API

### DIFF
--- a/hw_diag/tests/diagnostics/test_device_status_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_device_status_diagnostic.py
@@ -1,9 +1,13 @@
 import unittest
 from unittest.mock import patch
 
+import responses
+
 from hm_pyhelper.diagnostics.diagnostics_report import \
     DIAGNOSTICS_PASSED_KEY, DIAGNOSTICS_ERRORS_KEY, DiagnosticsReport
+
 from hw_diag.diagnostics.device_status_diagnostic import DeviceStatusDiagnostic
+from hw_diag.utilities import balena_supervisor
 
 
 class MockBalenaSupervisor:
@@ -42,3 +46,33 @@ class TestDeviceStatusDiagnostic(unittest.TestCase):
             DIAGNOSTICS_ERRORS_KEY: ['device_status', 'device_status'],
             'device_status': 'appState is applying'
         })
+
+    @responses.activate
+    @patch.dict(
+        balena_supervisor.os.environ,
+        {
+          'BALENA_SUPERVISOR_ADDRESS': 'http://127.0.0.1',
+          'BALENA_SUPERVISOR_API_KEY': 'secret'
+        },
+        clear=True
+    )
+    def test_empty_response(self):
+        responses.add(
+            responses.GET,
+            'http://127.0.0.1/v2/state/status?apikey=secret',
+            body='',
+            status=200
+        )
+
+        diagnostic = DeviceStatusDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: False,
+            DIAGNOSTICS_ERRORS_KEY: ['device_status', 'device_status'],
+            'device_status': 'appState is Failed due to supervisor API issue'
+        })
+
+        # resp = bs.get_device_status('appState')
+        # self.assertDictEqual(resp, {'appState': 'Failed due to supervisor API issue'})

--- a/hw_diag/tests/test_balena_supervisor.py
+++ b/hw_diag/tests/test_balena_supervisor.py
@@ -1,0 +1,149 @@
+import unittest
+from unittest.mock import patch
+
+import responses
+from requests.exceptions import ConnectionError, ConnectTimeout
+
+from hw_diag.utilities.balena_supervisor import BalenaSupervisor
+from hw_diag.utilities import balena_supervisor
+
+
+class TestBalenaSupervisor(unittest.TestCase):
+
+    def test_creation(self):
+        bs = BalenaSupervisor('http://127.0.0.1', 'secret')
+
+        assert bs.supervisor_address == 'http://127.0.0.1'
+        assert bs.supervisor_api_key == 'secret'
+        assert bs.headers == {'Content-type': 'application/json'}
+
+    @patch.dict(
+        balena_supervisor.os.environ,
+        {
+          'BALENA_SUPERVISOR_ADDRESS': 'http://127.0.0.1',
+          'BALENA_SUPERVISOR_API_KEY': 'secret'
+        },
+        clear=True
+    )
+    def test_creation_from_env(self):
+        bs = BalenaSupervisor.new_from_env()
+
+        assert bs.supervisor_address == 'http://127.0.0.1'
+        assert bs.supervisor_api_key == 'secret'
+        assert bs.headers == {'Content-type': 'application/json'}
+
+    @responses.activate
+    def test_device_status_success_response(self):
+        responses.add(
+            responses.GET,
+            'http://127.0.0.1/v2/state/status?apikey=secret',
+            status=200,
+            json={'appState': 'applied'}
+        )
+
+        bs = BalenaSupervisor('http://127.0.0.1', 'secret')
+        assert bs.get_device_status('appState') == 'applied'
+
+    @responses.activate
+    def test_device_status_error_on_connection_error(self):
+        responses.add(
+            responses.GET,
+            'http://127.0.0.1/v2/state/status?apikey=secret',
+            body=ConnectionError('Unable to connect')
+        )
+
+        bs = BalenaSupervisor('http://127.0.0.1', 'secret')
+
+        with self.assertRaises(Exception) as exp:
+            bs.get_device_status('appState')
+
+        assert str(exp.exception) == "Device status request failed"
+
+    @responses.activate
+    def test_device_status_error_on_connection_timeout(self):
+        responses.add(
+            responses.GET,
+            'http://127.0.0.1/v2/state/status?apikey=secret',
+            body=ConnectTimeout('Timout trying to make connection')
+        )
+
+        bs = BalenaSupervisor('http://127.0.0.1', 'secret')
+
+        with self.assertRaises(Exception) as exp:
+            bs.get_device_status('appState')
+
+        assert str(exp.exception) == "Device status request failed"
+
+    @responses.activate
+    def test_device_status_empty_response(self):
+        responses.add(
+            responses.GET,
+            'http://127.0.0.1/v2/state/status?apikey=secret',
+            body='',
+            status=200
+        )
+
+        bs = BalenaSupervisor('http://127.0.0.1', 'secret')
+
+        resp = bs.get_device_status('appState')
+        assert resp == 'Failed due to supervisor API issue'
+
+    @responses.activate
+    def test_shutdown_gateway_success_response(self):
+        responses.add(
+            responses.POST,
+            'http://127.0.0.1/v1/shutdown?apikey=secret',
+            status=200,
+            json={"Data": "OK", "Error": ""}
+        )
+
+        bs = BalenaSupervisor('http://127.0.0.1', 'secret')
+        resp = bs.shutdown()
+
+        assert resp['Data'] == 'OK'
+
+    @responses.activate
+    def test_shutdown_gateway_error_on_connection_error(self):
+        responses.add(
+            responses.POST,
+            'http://127.0.0.1/v1/shutdown?apikey=secret',
+            body=ConnectionError('Unable to connect')
+        )
+
+        bs = BalenaSupervisor('http://127.0.0.1', 'secret')
+
+        with self.assertRaises(Exception) as exp:
+            bs.shutdown()
+
+        assert str(exp.exception) == "supervisor API not accessible"
+
+    @responses.activate
+    def test_shutdown_gateway_error_on_connection_timeout(self):
+        responses.add(
+            responses.POST,
+            'http://127.0.0.1/v1/shutdown?apikey=secret',
+            body=ConnectTimeout('Timout trying to make connection')
+        )
+
+        bs = BalenaSupervisor('http://127.0.0.1', 'secret')
+
+        with self.assertRaises(Exception) as exp:
+            bs.shutdown()
+
+        assert str(exp.exception) == 'supervisor API not accessible'
+
+    @responses.activate
+    def test_shutdown_gateway_empty_response(self):
+        responses.add(
+            responses.POST,
+            'http://127.0.0.1/v1/shutdown?apikey=secret',
+            body='',
+            status=200
+        )
+
+        bs = BalenaSupervisor('http://127.0.0.1', 'secret')
+
+        with self.assertRaises(Exception) as exp:
+            bs.shutdown()
+
+        assert str(exp.exception) == 'shutdown failed due to supervisor API issue'

--- a/hw_diag/utilities/balena_supervisor.py
+++ b/hw_diag/utilities/balena_supervisor.py
@@ -1,4 +1,5 @@
 import os
+
 import requests
 from requests.exceptions import ConnectionError, ConnectTimeout
 
@@ -43,17 +44,23 @@ class BalenaSupervisor:
         response = self._make_request('POST', '/v1/shutdown')
         if response is None or response.ok is False:
             LOGGER.error("Device shutdown attempt failed.")
+            raise Exception('supervisor API not accessible')
 
-        return response.json()
+        try:
+            return response.json()
+        except Exception:
+            raise Exception('shutdown failed due to supervisor API issue')
 
     def get_device_status(self, key_to_return) -> str:
         """Get device status from balena supervisor API."""
         LOGGER.info("Retrieving device status using Balena supervisor.")
 
         response = self._make_request('GET', '/v2/state/status')
-        LOGGER.info(response.json())
         if response is None or response.ok is False:
             LOGGER.error("Device status request failed.")
             raise Exception("Device status request failed")
 
-        return response.json()[key_to_return]
+        try:
+            return response.json()[key_to_return]
+        except Exception:
+            return 'Failed due to supervisor API issue'


### PR DESCRIPTION
Better handling of empty json response from balena supervisor API and additional test cases for testing this outcome.

The root cause of the shutdown logic failing was that we were not raising an exception (required by ShutdownGatewayDiagnosticReport in order to register diagnostic failure). So even though we logged the error it looked like success in the diagnostic logic.

**Issue**

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [x] Thought about variable and method names

