### PR TITLE
Log as warning instead of error if fetching device status fails

### DIFF
--- a/hw_diag/utilities/balena_supervisor.py
+++ b/hw_diag/utilities/balena_supervisor.py
@@ -66,7 +66,7 @@ class BalenaSupervisor:
                   f"{response.status_code} {response.content}"
 
         if error_msg:
-            LOGGER.error(error_msg)
+            LOGGER.warning(error_msg)
             raise RuntimeError(error_msg)
 
         try:
@@ -75,5 +75,5 @@ class BalenaSupervisor:
             error_msg = "Supervisor API did not return valid json response.\n" + \
                         f"Couldn't find {key_to_return} key in response.\n" + \
                         f"Response content: {response.content}"
-            LOGGER.error(error_msg)
+            LOGGER.warning(error_msg)
             raise RuntimeError(error_msg)


### PR DESCRIPTION
Change log level from error to warning when fetching device status from supervisor api fails.

**Issue**

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

