### PR TITLE
Use ICMP Ping to local gateway in the watchdog

### DIFF
--- a/hw_diag/app.py
+++ b/hw_diag/app.py
@@ -62,7 +62,7 @@ def init_scheduled_tasks(app) -> None:
     @scheduler.task('interval', id='network_watchdog', hours=1, jitter=300)
     def run_network_watchdog_task():
         try:
-            watchdog = NetworkWatchdog.get_instance()
+            watchdog = NetworkWatchdog()
             watchdog.ensure_network_connection()
         except Exception as e:
             logging.warning(f'Unknown error while checking the network connectivity : {e}')

--- a/hw_diag/app.py
+++ b/hw_diag/app.py
@@ -59,10 +59,11 @@ def init_scheduled_tasks(app) -> None:
     def run_ship_diagnostics_task():
         perform_hw_diagnostics(ship=True)
 
+    watchdog = NetworkWatchdog()
+
     @scheduler.task('interval', id='network_watchdog', hours=1, jitter=300)
     def run_network_watchdog_task():
         try:
-            watchdog = NetworkWatchdog()
             watchdog.ensure_network_connection()
         except Exception as e:
             logging.warning(f'Unknown error while checking the network connectivity : {e}')

--- a/hw_diag/tests/test_network_watchdog.py
+++ b/hw_diag/tests/test_network_watchdog.py
@@ -23,7 +23,7 @@ class TestNetworkWatchdog(unittest.TestCase):
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
     def test_find_gateway_ip_success(self, _, __, ___):
-        watchdog = NetworkWatchdog.get_instance()
+        watchdog = NetworkWatchdog()
         gateway_ip = watchdog.find_gateway_ip()
         self.assertEqual(gateway_ip, self.TEST_GATEWAY_IP)
 
@@ -31,7 +31,7 @@ class TestNetworkWatchdog(unittest.TestCase):
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
     def test_find_gateway_ip_fail(self, _, __, ___):
-        watchdog = NetworkWatchdog.get_instance()
+        watchdog = NetworkWatchdog()
         gateway_ip = watchdog.find_gateway_ip()
         self.assertEqual(gateway_ip, '')
 
@@ -39,14 +39,14 @@ class TestNetworkWatchdog(unittest.TestCase):
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
     def test_save_previous_gateway_ip_success(self, _, __, ___):
-        watchdog = NetworkWatchdog.get_instance()
+        watchdog = NetworkWatchdog()
         watchdog.save_previous_gateway_ip(self.TEST_GATEWAY_IP)
 
     @patch.object(hw_diag.utilities.keystore.KeyStore, 'get', return_value=TEST_GATEWAY_IP)
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
     def test_get_previous_gateway_ip_success(self, _, __, ___):
-        watchdog = NetworkWatchdog.get_instance()
+        watchdog = NetworkWatchdog()
         previous_gateway_ip = watchdog.get_previous_gateway_ip()
         self.assertEqual(previous_gateway_ip, self.TEST_GATEWAY_IP)
 
@@ -54,7 +54,7 @@ class TestNetworkWatchdog(unittest.TestCase):
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
     def test_get_previous_gateway_ip_fail(self, _, __, ___):
-        watchdog = NetworkWatchdog.get_instance()
+        watchdog = NetworkWatchdog()
         previous_gateway_ip = watchdog.get_previous_gateway_ip()
         self.assertEqual(previous_gateway_ip, '')
 
@@ -64,7 +64,7 @@ class TestNetworkWatchdog(unittest.TestCase):
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
     def test_icmp_ping_success(self, _, __, ___):
-        watchdog = NetworkWatchdog.get_instance()
+        watchdog = NetworkWatchdog()
         result = watchdog.icmp_ping(self.TEST_GATEWAY_IP)
         self.assertTrue(result)
 
@@ -74,7 +74,7 @@ class TestNetworkWatchdog(unittest.TestCase):
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
     def test_icmp_ping_fail(self, _, __, ___):
-        watchdog = NetworkWatchdog.get_instance()
+        watchdog = NetworkWatchdog()
         result = watchdog.icmp_ping('')
         self.assertFalse(result)
 
@@ -82,7 +82,7 @@ class TestNetworkWatchdog(unittest.TestCase):
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
     def test_have_internet(self, _, __, ___):
-        watchdog = NetworkWatchdog.get_instance()
+        watchdog = NetworkWatchdog()
         have_internet = watchdog.have_internet()
         self.assertTrue(have_internet)
 
@@ -90,7 +90,7 @@ class TestNetworkWatchdog(unittest.TestCase):
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
     def test_no_internet(self, _, __, ___):
-        watchdog = NetworkWatchdog.get_instance()
+        watchdog = NetworkWatchdog()
         have_internet = watchdog.have_internet()
         self.assertFalse(have_internet)
 
@@ -101,7 +101,7 @@ class TestNetworkWatchdog(unittest.TestCase):
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
     def test_is_connected(self, _, __, ___, ____, _____):
-        watchdog = NetworkWatchdog.get_instance()
+        watchdog = NetworkWatchdog()
         is_connected = watchdog.is_connected()
         self.assertTrue(is_connected)
 
@@ -112,7 +112,7 @@ class TestNetworkWatchdog(unittest.TestCase):
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
     def test_not_connected(self, _, __, ___, ____, _____):
-        watchdog = NetworkWatchdog.get_instance()
+        watchdog = NetworkWatchdog()
         is_connected = watchdog.is_connected()
         self.assertFalse(is_connected)
 
@@ -120,7 +120,7 @@ class TestNetworkWatchdog(unittest.TestCase):
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
     def test_restart_network_manager_success(self, _, __, ___):
-        watchdog = NetworkWatchdog.get_instance()
+        watchdog = NetworkWatchdog()
         with self.assertLogs(level='INFO') as captured_logs:
             watchdog.restart_network_manager()
             self.assertIn('Network manager restarted:', captured_logs.output[0])
@@ -129,7 +129,7 @@ class TestNetworkWatchdog(unittest.TestCase):
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
     def test_ensure_network_connection_connected(self, _, __, ___):
-        watchdog = NetworkWatchdog.get_instance()
+        watchdog = NetworkWatchdog()
         with self.assertLogs(level='INFO') as captured_logs:
             watchdog.ensure_network_connection()
             self.assertIn('Ensuring the network connection...', captured_logs.output[0])
@@ -140,7 +140,7 @@ class TestNetworkWatchdog(unittest.TestCase):
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
     def test_ensure_network_connection_disconnected(self, _, __, ___, ____):
-        watchdog = NetworkWatchdog.get_instance()
+        watchdog = NetworkWatchdog()
         with self.assertLogs(level='INFO') as captured_logs:
             watchdog.ensure_network_connection()
             self.assertIn('Ensuring the network connection...', captured_logs.output[0])

--- a/hw_diag/tests/test_network_watchdog.py
+++ b/hw_diag/tests/test_network_watchdog.py
@@ -86,7 +86,7 @@ class TestNetworkWatchdog(unittest.TestCase):
         with self.assertLogs(level='INFO') as captured_logs:
             watchdog.ensure_network_connection()
             self.assertIn('Ensuring the network connection...', captured_logs.output[0])
-            self.assertIn('Watchdog has been up for', captured_logs.output[1])
+            self.assertIn('OS has been up for', captured_logs.output[1])
             self.assertIn('Network is working.', captured_logs.output[2])
 
     @patch.object(NetworkWatchdog, 'is_connected', return_value=False)
@@ -98,6 +98,6 @@ class TestNetworkWatchdog(unittest.TestCase):
         with self.assertLogs(level='INFO') as captured_logs:
             watchdog.ensure_network_connection()
             self.assertIn('Ensuring the network connection...', captured_logs.output[0])
-            self.assertIn('Watchdog has been up for', captured_logs.output[1])
+            self.assertIn('OS has been up for', captured_logs.output[1])
             self.assertIn(
                 'Network is not connected! Lost connectivity count=1', captured_logs.output[2])

--- a/hw_diag/tests/test_network_watchdog.py
+++ b/hw_diag/tests/test_network_watchdog.py
@@ -14,7 +14,7 @@ class TestNetworkWatchdog(unittest.TestCase):
                                                                         rtts=[0.3, 0.4]))
     def test_icmp_ping_success(self, _):
         watchdog = NetworkWatchdog()
-        result = watchdog.icmp_ping(self.TEST_GATEWAY_IP)
+        result = watchdog.is_ping_reachable(self.TEST_GATEWAY_IP)
         self.assertTrue(result)
 
     @patch('hw_diag.utilities.network_watchdog.ping', return_value=Host(address=TEST_GATEWAY_IP,
@@ -22,10 +22,10 @@ class TestNetworkWatchdog(unittest.TestCase):
                                                                         rtts=[]))
     def test_icmp_ping_fail(self, _):
         watchdog = NetworkWatchdog()
-        result = watchdog.icmp_ping('')
+        result = watchdog.is_ping_reachable('')
         self.assertFalse(result)
 
-    @patch.object(NetworkWatchdog, 'icmp_ping', return_value=True)
+    @patch.object(NetworkWatchdog, 'is_ping_reachable', return_value=True)
     @patch.object(NetworkManager, 'get_gateways', return_value=[TEST_GATEWAY_IP])
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
@@ -34,7 +34,7 @@ class TestNetworkWatchdog(unittest.TestCase):
         is_local_network_connected = watchdog.is_local_network_connected()
         self.assertTrue(is_local_network_connected)
 
-    @patch.object(NetworkWatchdog, 'icmp_ping', return_value=False)
+    @patch.object(NetworkWatchdog, 'is_ping_reachable', return_value=False)
     @patch.object(NetworkManager, 'get_gateways', return_value=[TEST_GATEWAY_IP])
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
@@ -43,13 +43,13 @@ class TestNetworkWatchdog(unittest.TestCase):
         is_local_network_connected = watchdog.is_local_network_connected()
         self.assertFalse(is_local_network_connected)
 
-    @patch.object(NetworkWatchdog, 'icmp_ping', return_value=True)
+    @patch.object(NetworkWatchdog, 'is_ping_reachable', return_value=True)
     def test_internet_connection_success(self, _):
         watchdog = NetworkWatchdog()
         is_internet_connected = watchdog.is_internet_connected()
         self.assertTrue(is_internet_connected)
 
-    @patch.object(NetworkWatchdog, 'icmp_ping', return_value=False)
+    @patch.object(NetworkWatchdog, 'is_ping_reachable', return_value=False)
     def test_internet_connection_fail(self, _):
         watchdog = NetworkWatchdog()
         is_internet_connected = watchdog.is_internet_connected()

--- a/hw_diag/tests/test_network_watchdog.py
+++ b/hw_diag/tests/test_network_watchdog.py
@@ -1,11 +1,82 @@
 import unittest
 from unittest.mock import patch
 
+from icmplib import Hop, Host
+
 import hw_diag
 from hw_diag.utilities.network_watchdog import NetworkWatchdog
 
 
 class TestNetworkWatchdog(unittest.TestCase):
+    TEST_INTERNAL_NETWORK_IP = '10.16.18.1'     # NOSONAR
+    TEST_GATEWAY_IP = '192.168.1.1'             # NOSONAR
+
+    @patch('hw_diag.utilities.network_watchdog.traceroute',
+           return_value=[Hop(address=TEST_INTERNAL_NETWORK_IP,
+                             packets_sent=2,
+                             rtts=[0.4, 0.3],
+                             distance=1),
+                         Hop(address=TEST_GATEWAY_IP,
+                             packets_sent=2,
+                             rtts=[0.4, 0.3],
+                             distance=2)])
+    @patch("dbus.SystemBus")
+    @patch("dbus.Interface")
+    def test_find_gateway_ip_success(self, _, __, ___):
+        watchdog = NetworkWatchdog.get_instance()
+        gateway_ip = watchdog.find_gateway_ip()
+        self.assertEqual(gateway_ip, self.TEST_GATEWAY_IP)
+
+    @patch('hw_diag.utilities.network_watchdog.traceroute', return_value=[])
+    @patch("dbus.SystemBus")
+    @patch("dbus.Interface")
+    def test_find_gateway_ip_fail(self, _, __, ___):
+        watchdog = NetworkWatchdog.get_instance()
+        gateway_ip = watchdog.find_gateway_ip()
+        self.assertEqual(gateway_ip, '')
+
+    @patch.object(hw_diag.utilities.keystore.KeyStore, 'set')
+    @patch("dbus.SystemBus")
+    @patch("dbus.Interface")
+    def test_save_previous_gateway_ip_success(self, _, __, ___):
+        watchdog = NetworkWatchdog.get_instance()
+        watchdog.save_previous_gateway_ip(self.TEST_GATEWAY_IP)
+
+    @patch.object(hw_diag.utilities.keystore.KeyStore, 'get', return_value=TEST_GATEWAY_IP)
+    @patch("dbus.SystemBus")
+    @patch("dbus.Interface")
+    def test_get_previous_gateway_ip_success(self, _, __, ___):
+        watchdog = NetworkWatchdog.get_instance()
+        previous_gateway_ip = watchdog.get_previous_gateway_ip()
+        self.assertEqual(previous_gateway_ip, self.TEST_GATEWAY_IP)
+
+    @patch.object(hw_diag.utilities.keystore.KeyStore, 'get', return_value='')
+    @patch("dbus.SystemBus")
+    @patch("dbus.Interface")
+    def test_get_previous_gateway_ip_fail(self, _, __, ___):
+        watchdog = NetworkWatchdog.get_instance()
+        previous_gateway_ip = watchdog.get_previous_gateway_ip()
+        self.assertEqual(previous_gateway_ip, '')
+
+    @patch('hw_diag.utilities.network_watchdog.ping', return_value=Host(address=TEST_GATEWAY_IP,
+                                                                        packets_sent=4,
+                                                                        rtts=[0.3, 0.4]))
+    @patch("dbus.SystemBus")
+    @patch("dbus.Interface")
+    def test_icmp_ping_success(self, _, __, ___):
+        watchdog = NetworkWatchdog.get_instance()
+        result = watchdog.icmp_ping(self.TEST_GATEWAY_IP)
+        self.assertTrue(result)
+
+    @patch('hw_diag.utilities.network_watchdog.ping', return_value=Host(address=TEST_GATEWAY_IP,
+                                                                        packets_sent=0,
+                                                                        rtts=[]))
+    @patch("dbus.SystemBus")
+    @patch("dbus.Interface")
+    def test_icmp_ping_fail(self, _, __, ___):
+        watchdog = NetworkWatchdog.get_instance()
+        result = watchdog.icmp_ping('')
+        self.assertFalse(result)
 
     @patch('socket.create_connection')
     @patch("dbus.SystemBus")
@@ -23,22 +94,24 @@ class TestNetworkWatchdog(unittest.TestCase):
         have_internet = watchdog.have_internet()
         self.assertFalse(have_internet)
 
-    @patch('socket.create_connection')
-    @patch.object(hw_diag.utilities.dbus_proxy.network_manager.NetworkManager, 'is_connected',
+    @patch.object(hw_diag.utilities.network_watchdog.NetworkWatchdog, 'icmp_ping',
                   return_value=True)
+    @patch.object(hw_diag.utilities.network_watchdog.NetworkWatchdog, 'find_gateway_ip')
+    @patch('socket.create_connection')
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
-    def test_is_connected(self, _, __, ___, ____):
+    def test_is_connected(self, _, __, ___, ____, _____):
         watchdog = NetworkWatchdog.get_instance()
         is_connected = watchdog.is_connected()
         self.assertTrue(is_connected)
 
-    @patch('socket.create_connection', side_effect=TimeoutError())
-    @patch.object(hw_diag.utilities.dbus_proxy.network_manager.NetworkManager, 'is_connected',
+    @patch.object(hw_diag.utilities.network_watchdog.NetworkWatchdog, 'icmp_ping',
                   return_value=False)
+    @patch.object(hw_diag.utilities.network_watchdog.NetworkWatchdog, 'find_gateway_ip')
+    @patch('socket.create_connection')
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
-    def test_not_connected(self, _, __, ___, ____):
+    def test_not_connected(self, _, __, ___, ____, _____):
         watchdog = NetworkWatchdog.get_instance()
         is_connected = watchdog.is_connected()
         self.assertFalse(is_connected)
@@ -55,22 +128,21 @@ class TestNetworkWatchdog(unittest.TestCase):
     @patch.object(NetworkWatchdog, 'is_connected', return_value=True)
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
-    def test_run_watchdog_connected(self, _, __, ___):
+    def test_ensure_network_connection_connected(self, _, __, ___):
         watchdog = NetworkWatchdog.get_instance()
         with self.assertLogs(level='INFO') as captured_logs:
             watchdog.ensure_network_connection()
-            self.assertIn('INFO:hw_diag.utilities.network_watchdog:Running the watchdog...',
-                          captured_logs.output)
-            self.assertIn('INFO:hw_diag.utilities.network_watchdog:Network is working.',
-                          captured_logs.output)
+            self.assertIn('Ensuring the network connection...', captured_logs.output[0])
+            self.assertIn('Network is working.', captured_logs.output[1])
 
     @patch.object(NetworkWatchdog, 'is_connected', return_value=False)
+    @patch.object(hw_diag.utilities.network_watchdog.NetworkWatchdog, 'restart_network_manager')
     @patch("dbus.SystemBus")
     @patch("dbus.Interface")
-    def test_run_watchdog_disconnected(self, _, __, ___):
+    def test_ensure_network_connection_disconnected(self, _, __, ___, ____):
         watchdog = NetworkWatchdog.get_instance()
         with self.assertLogs(level='INFO') as captured_logs:
             watchdog.ensure_network_connection()
-            self.assertIn('Running the watchdog...', captured_logs.output[0])
+            self.assertIn('Ensuring the network connection...', captured_logs.output[0])
             self.assertIn(
                 'Network is not connected! Lost connectivity count=1', captured_logs.output[1])

--- a/hw_diag/utilities/dbus_proxy/dbus_ids.py
+++ b/hw_diag/utilities/dbus_proxy/dbus_ids.py
@@ -19,6 +19,8 @@ class DBusIds:
     DBUS_NM_SERVICE = 'org.freedesktop.NetworkManager'
     DBUS_NM_PATH = '/org/freedesktop/NetworkManager'
     DBUS_NM_IF = 'org.freedesktop.NetworkManager'
+    DBUS_NM_ACTIVE_CONNECTION_IF = 'org.freedesktop.NetworkManager.Connection.Active'
+    DBUS_NM_IPV4CONFIG_IF = 'org.freedesktop.NetworkManager.IP4Config'
 
     # Systemd
     SYSTEMD_SERVICE = 'org.freedesktop.systemd1'

--- a/hw_diag/utilities/dbus_proxy/network_manager.py
+++ b/hw_diag/utilities/dbus_proxy/network_manager.py
@@ -34,6 +34,30 @@ class NetworkManager(DBusObject):
     def is_connected(self) -> bool:
         return 'Connected' in self.get_connect_state()
 
+    def get_gateways(self) -> list:
+        active_connections = self.get_property('ActiveConnections')
+
+        gateways = []
+        for connection_path in active_connections:
+            connection_proxy = self._system_bus.get_object(DBusIds.DBUS_NM_SERVICE, connection_path)
+            connection_props_if = dbus.Interface(connection_proxy,
+                                                 dbus_interface=DBusIds.DBUS_PROPERTIES_IF)
+            connection_props = connection_props_if.GetAll(DBusIds.DBUS_NM_ACTIVE_CONNECTION_IF)
+            connection_ipv4_path = connection_props.get("Ip4Config")
+
+            ipv4_obj = self._system_bus.get_object(DBusIds.DBUS_NM_SERVICE, connection_ipv4_path)
+            ipv4_props_if = dbus.Interface(ipv4_obj, dbus_interface=DBusIds.DBUS_PROPERTIES_IF)
+            ipv4_props = ipv4_props_if.GetAll(DBusIds.DBUS_NM_IPV4CONFIG_IF)
+            gateway = str(ipv4_props.get("Gateway"))
+
+            if gateway:
+                gateways.append(gateway)
+
+        # Remove duplicated gateways
+        gateways = list(set(gateways))
+
+        return gateways
+
 
 if __name__ == '__main__':
     nm = NetworkManager()

--- a/hw_diag/utilities/network_watchdog.py
+++ b/hw_diag/utilities/network_watchdog.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 import os
 import tempfile
@@ -6,10 +8,13 @@ from logging.handlers import RotatingFileHandler
 import socket
 
 from hm_pyhelper.logger import get_logger
+from icmplib import traceroute, ping
+
 from hw_diag.utilities.balena_supervisor import BalenaSupervisor
 from hw_diag.utilities.dbus_proxy.dbus_ids import DBusIds
 from hw_diag.utilities.dbus_proxy.network_manager import NetworkManager
 from hw_diag.utilities.dbus_proxy.systemd import Systemd
+from hw_diag.utilities.keystore import KeyStore
 
 LOGLEVEL = os.environ.get("LOGLEVEL", "DEBUG")
 _log_format = "%(asctime)s - [%(levelname)s] - (%(filename)s:%(lineno)d) - %(message)s"
@@ -20,11 +25,10 @@ class NetworkWatchdog:
 
     VOLUME_PATH = '/var/watchdog/'
     WATCHDOG_LOG_FILE_NAME = 'watchdog.log'
-    LAST_RESTART_FILE_NAME = 'last_restart.json'
-
     MAX_LOG_SIZE = 10 * 1024 * 1024  # 10 Mb
-    LAST_RESTART_KEY = 'last_restart'
-    LAST_RESTART_DATE_FORMAT = '%d/%m/%Y %H:%M:%S'
+
+    WATCHDOG_STATE_FILE_NAME = 'state.json'
+    PREVIOUS_GATEWAY_KEY = 'previous_gateway'
 
     # Failed connectivity count for the network manager to restart
     NM_RESTART_THRESHOLD = int(os.environ.get("NM_RESTART_THRESHOLD", 1))
@@ -49,7 +53,7 @@ class NetworkWatchdog:
     reboot_request_count = 0
 
     @staticmethod
-    def get_instance():
+    def get_instance() -> NetworkWatchdog:
         """ Static method to fetch the current instance.
         """
         if not NetworkWatchdog._instance:
@@ -70,11 +74,11 @@ class NetworkWatchdog:
         # Prepare the log file location
         if os.access(self.VOLUME_PATH, os.W_OK):
             self.log_file_path = os.path.join(self.VOLUME_PATH, self.WATCHDOG_LOG_FILE_NAME)
-            self.state_file_path = os.path.join(self.VOLUME_PATH, self.LAST_RESTART_FILE_NAME)
+            self.state_file_path = os.path.join(self.VOLUME_PATH, self.WATCHDOG_STATE_FILE_NAME)
         else:
             self.temp_dir = tempfile.TemporaryDirectory()
             self.log_file_path = os.path.join(self.temp_dir.name, self.WATCHDOG_LOG_FILE_NAME)
-            self.state_file_path = os.path.join(self.temp_dir.name, self.LAST_RESTART_FILE_NAME)
+            self.state_file_path = os.path.join(self.temp_dir.name, self.WATCHDOG_STATE_FILE_NAME)
 
         # Set up logger
         self.LOGGER = get_logger(__name__)
@@ -95,32 +99,70 @@ class NetworkWatchdog:
         if hasattr(self, 'temp_dir'):
             self.temp_dir.cleanup()
 
+    def find_gateway_ip(self) -> str:
+        hops = traceroute(self.PUBLIC_DNS_SERVER)
+
+        """
+        The local gateway IP should be the address of the 2nd hop.
+        Also first hop and 2nd hop should have the different addresses,
+        otherwise 2nd hop address is invalid address.
+        """
+        if len(hops) >= 2 and hops[0].address != hops[1].address and hops[1].is_alive:
+            gateway_ip = hops[1].address
+            self.LOGGER.info(f"Found local gateway {gateway_ip} using traceroute.")
+            self.save_previous_gateway_ip(gateway_ip)
+        else:
+            self.LOGGER.info("Failed to find local gateway using traceroute.")
+            gateway_ip = self.get_previous_gateway_ip()
+            self.LOGGER.info(f"Previous local gateway: {gateway_ip}")
+
+        return gateway_ip
+
+    def save_previous_gateway_ip(self, ip: str) -> None:
+        store = KeyStore(self.state_file_path)
+        store.set(self.PREVIOUS_GATEWAY_KEY, ip)
+
+    def get_previous_gateway_ip(self) -> str:
+        try:
+            return KeyStore(self.state_file_path).get(self.PREVIOUS_GATEWAY_KEY, '')
+        except Exception:
+            return ''
+
+    def icmp_ping(self, ip: str) -> bool:
+        try:
+            result = ping(ip)
+            return result and result.is_alive
+        except Exception:
+            return False
+
     def have_internet(self, timeout=10) -> bool:
         try:
             socket.setdefaulttimeout(timeout)
             sock = socket.create_connection((self.PUBLIC_DNS_SERVER, self.PUBLIC_DNS_PORT))
             sock.close()
             return True
-        except Exception as e:
-            self.LOGGER.info(f"internet not accessible: {e}")
+        except Exception:
             return False
 
     def is_connected(self) -> bool:
-        self.LOGGER.info("Checking the network connectivity.")
+        local_gateway_connectivity = False
+        gateway_ip = self.find_gateway_ip()
+        if gateway_ip:
+            local_gateway_connectivity = self.icmp_ping(gateway_ip)
 
-        # Log more details about the network connectivity and internet connectivity
-        self.LOGGER.info(f"Network manager state: {self.network_manager.get_connect_state()}")
-        self.LOGGER.info(f"Internet connectivity: {self.have_internet()}")
+        # Log more details about network connection status
+        self.LOGGER.info(f"Local gateway({gateway_ip}) connectivity: {local_gateway_connectivity}")
+        self.LOGGER.info(f"Internet({self.PUBLIC_DNS_SERVER}) connectivity: {self.have_internet()}")
 
-        return self.have_internet()
+        return local_gateway_connectivity
 
-    def restart_network_manager(self):
+    def restart_network_manager(self) -> None:
         """Restart hostOS NetworkManager service"""
         nm_restarted = self.network_manager_unit.wait_restart()
         self.LOGGER.info(f"Network manager restarted: {nm_restarted}")
 
     def ensure_network_connection(self) -> None:
-        self.LOGGER.info("Running the watchdog...")
+        self.LOGGER.info("Ensuring the network connection...")
 
         # If network is connected, nothing to do more
         if self.is_connected():
@@ -161,7 +203,5 @@ class NetworkWatchdog:
 
 
 if __name__ == '__main__':
-    print('Watchdog is running...')
     watchdog = NetworkWatchdog()
-    is_connected = watchdog.is_connected()
-    print("Is connected:", is_connected)
+    watchdog.ensure_network_connection()

--- a/hw_diag/utilities/network_watchdog.py
+++ b/hw_diag/utilities/network_watchdog.py
@@ -1,5 +1,4 @@
 from __future__ import annotations
-
 import logging
 import os
 import tempfile
@@ -21,8 +20,6 @@ _log_format = "%(asctime)s - [%(levelname)s] - (%(filename)s:%(lineno)d) - %(mes
 
 
 class NetworkWatchdog:
-    _instance = None
-
     VOLUME_PATH = '/var/watchdog/'
     WATCHDOG_LOG_FILE_NAME = 'watchdog.log'
     MAX_LOG_SIZE = 10 * 1024 * 1024  # 10 Mb
@@ -52,22 +49,7 @@ class NetworkWatchdog:
     # Static variable for saving the failed reboot count
     reboot_request_count = 0
 
-    @staticmethod
-    def get_instance() -> NetworkWatchdog:
-        """ Static method to fetch the current instance.
-        """
-        if not NetworkWatchdog._instance:
-            NetworkWatchdog()
-        return NetworkWatchdog._instance
-
     def __init__(self):
-        """ Constructor.
-               """
-        if NetworkWatchdog._instance is None:
-            NetworkWatchdog._instance = self
-        else:
-            raise RuntimeError("You cannot create another SingletonGovt class")
-
         # Save the uptime
         self.up_time = datetime.now()
 

--- a/hw_diag/utilities/network_watchdog.py
+++ b/hw_diag/utilities/network_watchdog.py
@@ -4,16 +4,12 @@ import os
 import tempfile
 from datetime import datetime, timedelta
 from logging.handlers import RotatingFileHandler
-import socket
-
 from hm_pyhelper.logger import get_logger
-from icmplib import traceroute, ping
-
+from icmplib import ping
 from hw_diag.utilities.balena_supervisor import BalenaSupervisor
 from hw_diag.utilities.dbus_proxy.dbus_ids import DBusIds
 from hw_diag.utilities.dbus_proxy.network_manager import NetworkManager
 from hw_diag.utilities.dbus_proxy.systemd import Systemd
-from hw_diag.utilities.keystore import KeyStore
 
 LOGLEVEL = os.environ.get("LOGLEVEL", "DEBUG")
 _log_format = "%(asctime)s - [%(levelname)s] - (%(filename)s:%(lineno)d) - %(message)s"
@@ -24,9 +20,6 @@ class NetworkWatchdog:
     WATCHDOG_LOG_FILE_NAME = 'watchdog.log'
     MAX_LOG_SIZE = 10 * 1024 * 1024  # 10 Mb
 
-    WATCHDOG_STATE_FILE_NAME = 'state.json'
-    PREVIOUS_GATEWAY_KEY = 'previous_gateway'
-
     # Failed connectivity count for the network manager to restart
     NM_RESTART_THRESHOLD = int(os.environ.get("NM_RESTART_THRESHOLD", 1))
     # Failed connectivity count for the hotspot to reboot
@@ -36,12 +29,10 @@ class NetworkWatchdog:
     # Full system reboot limited to once a day
     REBOOT_LIMIT_HOURS = int(os.environ.get("REBOOT_LIMIT_HOURS", 24))
 
-    # Public DNS server for checking internet connectivity
-    PUBLIC_DNS_SERVER = "8.8.8.8"       # NOSONAR
-    PUBLIC_DNS_PORT = 53
+    PUBLIC_SERVERS = ['8.8.8.8', '1.1.1.1']       # NOSONAR
 
     # Static variable for saving the up time of the hotspot
-    up_time = datetime.min
+    watchdog_start_time = datetime.min
 
     # Static variable for saving the lost connectivity count
     lost_count = 0
@@ -50,17 +41,15 @@ class NetworkWatchdog:
     reboot_request_count = 0
 
     def __init__(self):
-        # Save the uptime
-        self.up_time = datetime.now()
+        # Save the watchdog start time
+        self.watchdog_start_time = datetime.now()
 
         # Prepare the log file location
         if os.access(self.VOLUME_PATH, os.W_OK):
             self.log_file_path = os.path.join(self.VOLUME_PATH, self.WATCHDOG_LOG_FILE_NAME)
-            self.state_file_path = os.path.join(self.VOLUME_PATH, self.WATCHDOG_STATE_FILE_NAME)
         else:
             self.temp_dir = tempfile.TemporaryDirectory()
             self.log_file_path = os.path.join(self.temp_dir.name, self.WATCHDOG_LOG_FILE_NAME)
-            self.state_file_path = os.path.join(self.temp_dir.name, self.WATCHDOG_STATE_FILE_NAME)
 
         # Set up logger
         self.LOGGER = get_logger(__name__)
@@ -70,81 +59,60 @@ class NetworkWatchdog:
         handler.setFormatter(logging.Formatter(_log_format))
         self.LOGGER.addHandler(handler)
 
-        self.systemd_proxy = Systemd()
-        self.network_manager_unit = self.systemd_proxy.get_unit(DBusIds.NETWORK_MANAGER_UNIT_NAME)
-        self.network_manager = NetworkManager()
-
         # Log the watchdog intro
-        self.LOGGER.info("Watchdog is started!")
+        self.LOGGER.info("Watchdog started!")
 
     def __del__(self):
         if hasattr(self, 'temp_dir'):
             self.temp_dir.cleanup()
 
-    def find_gateway_ip(self) -> str:
-        hops = traceroute(self.PUBLIC_DNS_SERVER)
-
-        """
-        The local gateway IP should be the address of the 2nd hop.
-        Also first hop and 2nd hop should have the different addresses,
-        otherwise 2nd hop address is invalid address.
-        """
-        if len(hops) >= 2 and hops[0].address != hops[1].address and hops[1].is_alive:
-            gateway_ip = hops[1].address
-            self.LOGGER.info(f"Found local gateway {gateway_ip} using traceroute.")
-            self.save_previous_gateway_ip(gateway_ip)
-        else:
-            self.LOGGER.info("Failed to find local gateway using traceroute.")
-            gateway_ip = self.get_previous_gateway_ip()
-            self.LOGGER.info(f"Previous local gateway: {gateway_ip}")
-
-        return gateway_ip
-
-    def save_previous_gateway_ip(self, ip: str) -> None:
-        store = KeyStore(self.state_file_path)
-        store.set(self.PREVIOUS_GATEWAY_KEY, ip)
-
-    def get_previous_gateway_ip(self) -> str:
-        try:
-            return KeyStore(self.state_file_path).get(self.PREVIOUS_GATEWAY_KEY, '')
-        except Exception:
-            return ''
-
     def icmp_ping(self, ip: str) -> bool:
         try:
-            result = ping(ip)
-            return result and result.is_alive
+            ping_target = ping(ip)
+            reachable = ping_target and ping_target.address == ip and ping_target.is_alive
+            if reachable:
+                self.LOGGER.info(f'{ip} is reachable.')
+            else:
+                self.LOGGER.info(f'{ip} is not reachable.')
+            return reachable
         except Exception:
             return False
 
-    def have_internet(self, timeout=10) -> bool:
-        try:
-            socket.setdefaulttimeout(timeout)
-            sock = socket.create_connection((self.PUBLIC_DNS_SERVER, self.PUBLIC_DNS_PORT))
-            sock.close()
-            return True
-        except Exception:
-            return False
+    def is_local_network_connected(self) -> bool:
+        network_manager = NetworkManager()
+        gateways = network_manager.get_gateways()
+        for gateway in gateways:
+            if self.icmp_ping(gateway):
+                return True
+        return False
+
+    def is_internet_connected(self) -> bool:
+        for public_server in self.PUBLIC_SERVERS:
+            if self.icmp_ping(public_server):
+                return True
+        return False
 
     def is_connected(self) -> bool:
-        local_gateway_connectivity = False
-        gateway_ip = self.find_gateway_ip()
-        if gateway_ip:
-            local_gateway_connectivity = self.icmp_ping(gateway_ip)
+        is_local_network_connected = self.is_local_network_connected()
+        self.LOGGER.info(f"Local network connection: {is_local_network_connected}")
 
-        # Log more details about network connection status
-        self.LOGGER.info(f"Local gateway({gateway_ip}) connectivity: {local_gateway_connectivity}")
-        self.LOGGER.info(f"Internet({self.PUBLIC_DNS_SERVER}) connectivity: {self.have_internet()}")
+        is_internet_connected = self.is_internet_connected()
+        self.LOGGER.info(f"Internet connection: {is_internet_connected}")
 
-        return local_gateway_connectivity
+        return is_local_network_connected
 
     def restart_network_manager(self) -> None:
         """Restart hostOS NetworkManager service"""
-        nm_restarted = self.network_manager_unit.wait_restart()
+        systemd_proxy = Systemd()
+        network_manager_unit = systemd_proxy.get_unit(DBusIds.NETWORK_MANAGER_UNIT_NAME)
+        nm_restarted = network_manager_unit.wait_restart()
         self.LOGGER.info(f"Network manager restarted: {nm_restarted}")
 
     def ensure_network_connection(self) -> None:
         self.LOGGER.info("Ensuring the network connection...")
+
+        up_time = datetime.now() - self.watchdog_start_time
+        self.LOGGER.info(f"Watchdog has been up for {up_time}")
 
         # If network is connected, nothing to do more
         if self.is_connected():
@@ -157,17 +125,10 @@ class NetworkWatchdog:
         self.LOGGER.warning(
             f"Network is not connected! Lost connectivity count={self.lost_count}")
 
-        if self.lost_count >= self.NM_RESTART_THRESHOLD:
-            self.LOGGER.warning(
-                "Reached threshold for nm restart for recovering network.")
-            self.restart_network_manager()
-            self.LOGGER.info("Restarted the network connection.")
-
         if self.lost_count >= self.FULL_REBOOT_THRESHOLD:
             self.LOGGER.warning(
-                "Reached threshold for system reboot for recovering network.")
-            if self.up_time + timedelta(
-                    hours=self.REBOOT_LIMIT_HOURS) > datetime.now():
+                "Reached threshold for system reboot to recover network.")
+            if up_time < timedelta(hours=self.REBOOT_LIMIT_HOURS):
                 self.LOGGER.info(
                     f"Hotspot has been restarted already within {self.REBOOT_LIMIT_HOURS}hour(s)."
                     f" Skip the rebooting.")
@@ -182,6 +143,10 @@ class NetworkWatchdog:
 
             balena_supervisor = BalenaSupervisor.new_from_env()
             balena_supervisor.reboot(force=force_reboot)
+        elif self.lost_count >= self.NM_RESTART_THRESHOLD:
+            self.LOGGER.warning(
+                "Reached threshold for Network Manager restart to recover network.")
+            self.restart_network_manager()
 
 
 if __name__ == '__main__':

--- a/hw_diag/utilities/network_watchdog.py
+++ b/hw_diag/utilities/network_watchdog.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
-from datetime import datetime, timedelta
+from uptime import uptime
+from datetime import timedelta
 from logging.handlers import RotatingFileHandler
 from hm_pyhelper.logger import get_logger
 from icmplib import ping
@@ -31,9 +32,6 @@ class NetworkWatchdog:
 
     PUBLIC_SERVERS = ['8.8.8.8', '1.1.1.1']       # NOSONAR
 
-    # Static variable for saving the up time of the hotspot
-    watchdog_start_time = datetime.min
-
     # Static variable for saving the lost connectivity count
     lost_count = 0
 
@@ -41,9 +39,6 @@ class NetworkWatchdog:
     reboot_request_count = 0
 
     def __init__(self):
-        # Save the watchdog start time
-        self.watchdog_start_time = datetime.now()
-
         # Prepare the log file location
         if os.access(self.VOLUME_PATH, os.W_OK):
             self.log_file_path = os.path.join(self.VOLUME_PATH, self.WATCHDOG_LOG_FILE_NAME)
@@ -58,9 +53,6 @@ class NetworkWatchdog:
         handler.setLevel(LOGLEVEL)
         handler.setFormatter(logging.Formatter(_log_format))
         self.LOGGER.addHandler(handler)
-
-        # Log the watchdog intro
-        self.LOGGER.info("Watchdog started!")
 
     def __del__(self):
         if hasattr(self, 'temp_dir'):
@@ -111,8 +103,8 @@ class NetworkWatchdog:
     def ensure_network_connection(self) -> None:
         self.LOGGER.info("Ensuring the network connection...")
 
-        up_time = datetime.now() - self.watchdog_start_time
-        self.LOGGER.info(f"Watchdog has been up for {up_time}")
+        up_time = timedelta(seconds=uptime())
+        self.LOGGER.info(f"OS has been up for {up_time}")
 
         # If network is connected, nothing to do more
         if self.is_connected():

--- a/hw_diag/utilities/network_watchdog.py
+++ b/hw_diag/utilities/network_watchdog.py
@@ -66,7 +66,7 @@ class NetworkWatchdog:
         if hasattr(self, 'temp_dir'):
             self.temp_dir.cleanup()
 
-    def icmp_ping(self, ip: str) -> bool:
+    def is_ping_reachable(self, ip: str) -> bool:
         try:
             ping_target = ping(ip)
             reachable = ping_target and ping_target.address == ip and ping_target.is_alive
@@ -82,13 +82,13 @@ class NetworkWatchdog:
         network_manager = NetworkManager()
         gateways = network_manager.get_gateways()
         for gateway in gateways:
-            if self.icmp_ping(gateway):
+            if self.is_ping_reachable(gateway):
                 return True
         return False
 
     def is_internet_connected(self) -> bool:
         for public_server in self.PUBLIC_SERVERS:
-            if self.icmp_ping(public_server):
+            if self.is_ping_reachable(public_server):
                 return True
         return False
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ dbus-python==1.2.16
 hm-pyhelper==0.13.25
 python-gnupg==0.4.8
 pydantic==1.9.0
+icmplib==3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ hm-pyhelper==0.13.25
 python-gnupg==0.4.8
 pydantic==1.9.0
 icmplib==3.0.3
+uptime==3.0.1


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-diag/issues/387
- Summary:
Find out the correct connection status to the local gateway and the internet so that watchdog can work reliably.

**How**
- Use dbus interface to the network manager to get the local gateway IP inside the diagnostics container.
- Use ICMP `ping` method to check the connection status to the local gateway(ex, 192.168.0.1) and public IP(8.8.8.8).

**Screenshots**
<!-- Include images, if possible. -->

**References**
- https://github.com/NebraLtd/hm-diag/issues/343
- [icmplib](https://pypi.org/project/icmplib/)

**Checklist**

- [x] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

