### PR TITLE
Use SWARM_KEY_URI from hardware definitions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ requests==2.26.0
 retry==0.9.2
 sentry-sdk[Flask]==1.5.1
 dbus-python==1.2.16
-hm-pyhelper==0.13.25
+hm-pyhelper==0.13.29
 python-gnupg==0.4.8
 pydantic==1.9.0
 icmplib==3.0.3


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-pyhelper/issues/164
- Summary:
In [detect_ecc](https://github.com/NebraLtd/hm-diag/blob/22a67fad95cd889f5ad45900657afd9a17b09dfb/hw_diag/utilities/hardware.py#L186), `KEY_STORAGE_BUS` field of hardware definitions is referenced to get the i2c bus number of ECC.
In the process of updating `gateway_mfr_rs` to the latest version v0.2.1, `SWARM_KEY_URI` field is added to the hardware definitions to specify the address of the ECC.
We need to refactor `detect_ecc()` method so that either the `SWARM_KEY_URI` or `KEY_STORAGE_BUS` field of the hardware definition can be used for specifying the ECC address.

**How**
In `detect_ecc()` method:
- Try to get the ECC address from `SWARM_KEY_URI` field.
- If above fails, try to get the ECC bus number from `KEY_STORAGE_BUS` field.
- If above fails, fall back to the ECC bus number as 1.

Added the test cases.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

