### PR TITLE
pull pyhelper-0.13.32 that fixes wlan0 not found sentry error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ requests==2.26.0
 retry==0.9.2
 sentry-sdk[Flask]==1.5.1
 dbus-python==1.2.16
-hm-pyhelper==0.13.29
+hm-pyhelper==0.13.32
 python-gnupg==0.4.8
 pydantic==1.9.0
 icmplib==3.0.3


### PR DESCRIPTION
* use pyhelper version 0.13.32 that includes variant renames and sentry
  fixes

**[Issue](https://github.com/NebraLtd/hm-pyhelper/issues/171)**

- Link: https://github.com/NebraLtd/hm-pyhelper/issues/171
- Summary: use pyhelper version with new mappings.

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

