### PR TITLE
Add balena UUID and balena fleet name to sentry tag

### DIFF
--- a/hw_diag/app.py
+++ b/hw_diag/app.py
@@ -2,36 +2,29 @@ from datetime import datetime
 import logging
 import os
 import traceback
-import sentry_sdk
 from datetime import timedelta
-
 from flask import Flask
 from flask_apscheduler import APScheduler
 from retry import retry
-from sentry_sdk.integrations.logging import LoggingIntegration
-
 from hw_diag.cache import cache
 from hw_diag.tasks import perform_hw_diagnostics
 from hw_diag.utilities.network_watchdog import NetworkWatchdog
+from hw_diag.utilities.sentry import init_sentry
 from hw_diag.views.diagnostics import DIAGNOSTICS
 from hw_diag.utilities.quectel import ensure_quectel_health
 from hm_pyhelper.miner_param import provision_key
-from hm_pyhelper.util.sentry import before_send_filter
-from sentry_sdk.integrations.flask import FlaskIntegration
 
+
+SENTRY_DSN = os.getenv('SENTRY_DIAG')
 DIAGNOSTICS_VERSION = os.getenv('DIAGNOSTICS_VERSION')
-DSN_SENTRY = os.getenv('SENTRY_DIAG')
+BALENA_ID = os.getenv('BALENA_DEVICE_UUID')
+BALENA_APP = os.getenv('BALENA_APP_NAME')
 
-sentry_logging = LoggingIntegration(
-    level=logging.CRITICAL,
-    event_level=logging.CRITICAL
-)
-
-sentry_sdk.init(
-    dsn=DSN_SENTRY,
-    integrations=[sentry_logging, FlaskIntegration()],
-    release=f"diagnostics@{DIAGNOSTICS_VERSION}",
-    before_send=before_send_filter
+init_sentry(
+    sentry_dsn=SENTRY_DSN,
+    release=DIAGNOSTICS_VERSION,
+    balena_id=BALENA_ID,
+    balena_app=BALENA_APP
 )
 
 DEBUG = bool(os.getenv('DEBUG', '0'))

--- a/hw_diag/utilities/sentry.py
+++ b/hw_diag/utilities/sentry.py
@@ -1,9 +1,6 @@
-import logging
-
 import sentry_sdk
 from hm_pyhelper.util.sentry import before_send_filter
 from sentry_sdk.integrations.flask import FlaskIntegration
-from sentry_sdk.integrations.logging import LoggingIntegration
 
 
 def init_sentry(sentry_dsn, release, balena_id, balena_app):
@@ -15,14 +12,9 @@ def init_sentry(sentry_dsn, release, balena_id, balena_app):
     if not sentry_dsn:
         return
 
-    sentry_logging = LoggingIntegration(
-        level=logging.CRITICAL,
-        event_level=logging.CRITICAL
-    )
-
     sentry_sdk.init(
         dsn=sentry_dsn,
-        integrations=[sentry_logging, FlaskIntegration()],
+        integrations=[FlaskIntegration()],
         release=f"diagnostics@{release}",
         before_send=before_send_filter
     )

--- a/hw_diag/utilities/sentry.py
+++ b/hw_diag/utilities/sentry.py
@@ -1,0 +1,31 @@
+import logging
+
+import sentry_sdk
+from hm_pyhelper.util.sentry import before_send_filter
+from sentry_sdk.integrations.flask import FlaskIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
+
+
+def init_sentry(sentry_dsn, release, balena_id, balena_app):
+    """
+    Initialize sentry with balena_id and balena_app as tag.
+    If sentry_dsn is not set, do nothing.
+    """
+
+    if not sentry_dsn:
+        return
+
+    sentry_logging = LoggingIntegration(
+        level=logging.CRITICAL,
+        event_level=logging.CRITICAL
+    )
+
+    sentry_sdk.init(
+        dsn=sentry_dsn,
+        integrations=[sentry_logging, FlaskIntegration()],
+        release=f"diagnostics@{release}",
+        before_send=before_send_filter
+    )
+
+    sentry_sdk.set_tag("balena_id", balena_id)
+    sentry_sdk.set_tag("balena_app", balena_app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ click==7.1.2
 gunicorn==20.1.0
 requests==2.26.0
 retry==0.9.2
-sentry-sdk[Flask]==1.5.1
+sentry-sdk[Flask]==1.6.0
 dbus-python==1.2.16
 hm-pyhelper==0.13.32
 python-gnupg==0.4.8


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-diag/issues/405
- Summary:
Add balena device UUID and balena app name(fleet name) to senty issues as a tag. 
Sentry tag is very convenient for filtering, tag-distribution maps, the frequency and the last time that Sentry has seen a tag.
The primary benefit of the Balena device UUID tag is that it enables further analysis of the Sentry problem on the Balena dashboard.

**How**
- Inside the balena container, get the balena UUID from environment variable `BALENA_DEVICE_UUID` and get balena app name from environment variable `BALENA_APP_NAME`.
- Set sentry tag with balena UUID and balena app name respectively.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

