### PR TITLE
feat: Consolidate diagnostics page changes for light hotspot activati…

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ The images are tagged using the docker long and short commit SHAs for that relea
 ## Light hotspot notes
 Helium network is transitioning to light hotspot mode. During the transition, there is a possibility of hotspot going back and forth between light and full blockchain sync mode. We support a environment variable (DISPLAY_MINER_INFO) to disable showing blockchain mining information so that administrators can enable/disable its visibility to avoid confusion among their customers.
 
-The envvar default to true.
+The envvar default to false.
 If set and set to anything other than true, following mining information will be hidden:
 - Sync Percentage
 - Miner Connected To Blockchain

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -69,7 +69,7 @@ def get_diagnostics():
     diagnostics = read_diagnostics_file()
     display_lte = should_display_lte(diagnostics)
     now = datetime.utcnow()
-    display_miner = os.getenv("DISPLAY_MINER_INFO", "true").lower() == "true"
+    display_miner = os.getenv("DISPLAY_MINER_INFO", "false").lower() == "true"
     template_filename = 'diagnostics_page_light_miner.html'
     if display_miner:
         template_filename = 'diagnostics_page.html'


### PR DESCRIPTION
change the default behaviour to not show miner info unless env
variable is set.

**[Issue](https://github.com/NebraLtd/hm-diag/issues/357)**

- Link: https://github.com/NebraLtd/hm-diag/issues/357
- Summary: change DISPLAY_MINER_INFO env defaut to false.

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

