### PR TITLE
feat: Make most fields in big query diagnostic schema as optional #404

### DIFF
--- a/bigquery/diag_schema.json
+++ b/bigquery/diag_schema.json
@@ -20,37 +20,37 @@
     "type": "STRING"
   },
   {
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "name": "BN",
     "type": "STRING"
   },
   {
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "name": "ID",
     "type": "STRING"
   },
   {
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "name": "BA",
     "type": "STRING"
   },
   {
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "name": "FR",
     "type": "STRING"
   },
   {
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "name": "FW",
     "type": "STRING"
   },
   {
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "name": "VA",
     "type": "STRING"
   },
   {
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "name": "serial_number",
     "type": "STRING"
   },
@@ -65,17 +65,17 @@
     "type": "BOOLEAN"
   },
   {
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "name": "PK",
     "type": "STRING"
   },
   {
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "name": "OK",
     "type": "STRING"
   },
   {
-    "mode": "REQUIRED",
+    "mode": "NULLABLE",
     "name": "AN",
     "type": "STRING"
   },

--- a/hw_diag/diagnostics/bigquery_data_model.py
+++ b/hw_diag/diagnostics/bigquery_data_model.py
@@ -8,18 +8,18 @@ class DiagnosticDataModel(BaseModel):
     last_updated: str
     E0: Optional[str]
     W0: Optional[str]
-    BN: str
-    ID: str
-    BA: str
-    FR: str
-    FW: str
-    VA: str
-    serial_number: str
+    BN: Optional[str]
+    ID: Optional[str]
+    BA: Optional[str]
+    FR: Optional[str]
+    FW: Optional[str]
+    VA: Optional[str]
+    serial_number: Optional[str]
     ECC: Optional[bool]
     LOR: Optional[bool]
-    PK: str
-    OK: str
-    AN: str
+    PK: Optional[str]
+    OK: Optional[str]
+    AN: Optional[str]
     MC: Optional[bool]
     MD: Optional[bool]
     MH: Optional[int]

--- a/hw_diag/tests/test_gcs_shipper.py
+++ b/hw_diag/tests/test_gcs_shipper.py
@@ -48,7 +48,7 @@ class TestUploadDiagnostics(unittest.TestCase):
         mock_requests.post = MagicMock()
         mock_requests.post.return_value = OKResponse()
         diag_data = valid_diagnostic_data().copy()
-        diag_data.pop('serial_number')
+        diag_data.pop('last_updated')
         retval = upload_diagnostics(diag_data, True)
         self.assertFalse(retval)
 


### PR DESCRIPTION
* start using new schema for diagnostic data

**https://github.com/NebraLtd/hm-diag/issues/404**

- Link: https://github.com/NebraLtd/hm-diag/issues/404
- Summary: use new schema for diag data that makes most fields optional

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

