### PR TITLE
feat: grab i2c address from hardware definitions and add override

### DIFF
--- a/hw_diag/tests/test_hardware.py
+++ b/hw_diag/tests/test_hardware.py
@@ -378,26 +378,6 @@ class TestHardware(unittest.TestCase):
 
     @patch.dict('hw_diag.utilities.hardware.variant_definitions', {
         "HNT-TEST": {
-            "KEY_STORAGE_BUS": "/dev/i2c-3",
-            "NO_SWARM_KEY_URI": "ecc://i2c-7:96?slot=0",
-        }
-    })
-    @patch('hw_diag.utilities.hardware.config_search_param', return_value=True)
-    def test_detect_ecc_from_KEY_STORAGE_BUS(
-            self,
-            mocked_config_search_param,
-    ):
-        diagnostics = {
-            'VA': 'HNT-TEST',
-            'ECC': None,
-        }
-        detect_ecc(diagnostics)
-        self.assertTrue(diagnostics['ECC'])
-        mocked_config_search_param.assert_called_once_with('i2cdetect -y 3',
-                                                           self.ECC_I2C_DETECT_PATTERN)
-
-    @patch.dict('hw_diag.utilities.hardware.variant_definitions', {
-        "HNT-TEST": {
             "NO_KEY_STORAGE_BUS": "/dev/i2c-3",
             "NO_SWARM_KEY_URI": "ecc://i2c-7:96?slot=0",
         }

--- a/hw_diag/tests/test_hardware.py
+++ b/hw_diag/tests/test_hardware.py
@@ -4,7 +4,8 @@ from unittest.mock import patch, MagicMock
 from dbus import DBusException
 
 from hw_diag.utilities.hardware import get_public_keys_and_ignore_errors, \
-    get_wifi_devices, get_ble_devices, get_lte_devices, detect_ecc  # noqa
+    get_wifi_devices, get_ble_devices, get_lte_devices, detect_ecc, \
+    parse_i2c_address, parse_i2c_bus # noqa
 
 
 class TestHardware(unittest.TestCase):

--- a/hw_diag/tests/test_hardware.py
+++ b/hw_diag/tests/test_hardware.py
@@ -395,3 +395,17 @@ class TestHardware(unittest.TestCase):
         self.assertTrue(diagnostics['ECC'])
         mocked_config_search_param.assert_called_once_with('i2cdetect -y 1',
                                                            self.ECC_I2C_DETECT_PATTERN)
+
+    def test_parse_i2c_address(self):
+        port = 96
+        output = parse_i2c_address(port)
+        hex_i2c_address = '60'
+
+        self.assertEqual(output, hex_i2c_address)
+
+    def test_parse_i2c_bus(self):
+        bus = i2c-1
+        output = parse_i2c_bus(bus)
+        i2c_bus = '1'
+
+        self.assertEqual(output, i2c_bus)

--- a/hw_diag/tests/test_hardware.py
+++ b/hw_diag/tests/test_hardware.py
@@ -405,7 +405,7 @@ class TestHardware(unittest.TestCase):
         self.assertEqual(output, hex_i2c_address)
 
     def test_parse_i2c_bus(self):
-        bus = i2c-1
+        bus = 'i2c-1'
         output = parse_i2c_bus(bus)
         i2c_bus = '1'
 


### PR DESCRIPTION
**Issue**

- Link: #500 
- Summary: grab i2c address from hardware definitions and add override

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

- allows us to get the i2c address from the SWARM_KEY_URI in hm-pyhelper instead of hard coding it
- removes legacy KEY_STORAGE_BUS commands and corresponding test cases
- adds SWARM_KEY_URI_OVERRIDE to override the key location using an environment variable

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Closes: #500

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [x] Documentation added
- [x] Thought about variable and method names

