### PR TITLE
chore(deps): bump sentry-sdk from 1.12.1 to 1.17.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ click==8.1.3
 gunicorn==20.1.0
 requests==2.28.1
 retry==0.9.2
-sentry-sdk[Flask]==1.12.1
+sentry-sdk[Flask]==1.17.0
 dbus-python==1.2.16
 hm-pyhelper==0.13.56
 python-gnupg==0.5.0


### PR DESCRIPTION
Ref https://github.com/NebraLtd/hm-pktfwd/pull/135

**Issue**

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

