### PR TITLE
Added newly required grpcio library dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,7 +13,7 @@ requests==2.28.1
 retry==0.9.2
 sentry-sdk[Flask]==1.17.0
 dbus-python==1.2.16
-hm-pyhelper==0.14.0
+hm-pyhelper==0.14.4
 python-gnupg==0.5.0
 pydantic==1.10.4
 ipaddress==1.0.23
@@ -21,3 +21,4 @@ icmplib==3.0.3
 uptime==3.0.1
 persist-queue==0.8.0
 psutil==5.9.4
+grpcio==1.53.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,3 +2,4 @@ pytest
 pytest-cov
 flake8
 responses
+grpcio==1.53.0


### PR DESCRIPTION
grpcio has to be added externally to hm-pyhelper from 0.14.4+

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

