### PR TITLE
fix: more accurate memory usage statistics

### DIFF
--- a/hw_diag/utilities/hardware.py
+++ b/hw_diag/utilities/hardware.py
@@ -349,10 +349,12 @@ def get_device_metrics():
         except Exception:
             temperature = 0
 
+    memory_used = psutil.virtual_memory().total - psutil.virtual_memory().available
+
     return {
         'cpu': psutil.cpu_percent(),
         'memory_total': psutil.virtual_memory().total,
-        'memory_used': psutil.virtual_memory().used,
+        'memory_used': memory_used,
         'disk_total': psutil.disk_usage('/').total,
         'disk_used': psutil.disk_usage('/').used,
         'temperature': temperature


### PR DESCRIPTION
As per https://psutil.readthedocs.io/en/latest/#psutil.virtual_memory the best way to calculate available and used memory is by using the "total" and "available" metrics.

Also see https://github.com/giampaolo/psutil/blob/master/scripts/meminfo.py

Related to #485 and #522

**Issue**

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

