### PR TITLE
ECC diagnostics: Ignore lockable test failures in 0x58 ECCs

### DIFF
--- a/hw_diag/diagnostics/ecc_diagnostic.py
+++ b/hw_diag/diagnostics/ecc_diagnostic.py
@@ -1,11 +1,12 @@
 import json
+import re
 
 from hm_pyhelper.diagnostics import DiagnosticsReport
 from hm_pyhelper.lock_singleton import ResourceBusyError
-from hm_pyhelper.miner_param import LOGGER, get_gateway_mfr_test_result
+from hm_pyhelper.miner_param import LOGGER, get_ecc_location, get_gateway_mfr_test_result
 from hm_pyhelper.diagnostics.diagnostic import Diagnostic
 from hm_pyhelper.exceptions import ECCMalfunctionException,\
-    GatewayMFRFileNotFoundException
+    GatewayMFRFileNotFoundException, UnknownVariantException
 
 
 class EccDiagnostic(Diagnostic):
@@ -16,6 +17,35 @@ class EccDiagnostic(Diagnostic):
     def __init__(self):
         super(EccDiagnostic, self).__init__(self.KEY, self.FRIENDLY_NAME)
 
+    def is_0x58_pass(self, ecc_tests: dict) -> bool:
+        """ECCs at 0x58 are expected to fail the `lockable` test.
+        If this is really the only test that fails, consider it a pass.
+        """
+
+        tests = ecc_tests.get('tests', {})
+        fail_count = len([t for t in tests.values() if t['result'] == 'fail'])
+
+        try:
+            ecc_location = get_ecc_location()
+            m = re.search(r':(\d+)(\?slot=(\d+))?', ecc_location)
+            if m:
+                groups = m.groups()
+                address, slot = (
+                    int(groups[0]) if groups[0] is not None else 0x60,
+                    int(groups[2]) if groups[2] is not None else 0,
+                )
+            else:
+                address, slot = 0x60, 0
+        except UnknownVariantException:
+            address, slot = 0x60, 0
+
+        try:
+            lockable = tests[f'key_config({slot})']['checks']['lockable'] == 'true'
+        except KeyError:
+            lockable = False
+
+        return fail_count == 1 and lockable is False and address == 0x58
+
     def perform_test(self, diagnostics_report: DiagnosticsReport) -> None:
         try:
             ecc_tests = get_gateway_mfr_test_result()
@@ -23,9 +53,13 @@ class EccDiagnostic(Diagnostic):
             if ecc_tests['result'] == 'pass':
                 diagnostics_report.record_result(True, self)
             else:
-                msg = "gateway_mfr test finished with error, %s" % \
-                      str(json.dumps(ecc_tests))
-                diagnostics_report.record_failure(msg, self)
+                if self.is_0x58_pass(ecc_tests):
+                    LOGGER.info("Ignoring wrong lockable flag on 0x58 ECC")
+                    diagnostics_report.record_result(True, self)
+                else:
+                    msg = "gateway_mfr test finished with error, %s" % \
+                          str(json.dumps(ecc_tests))
+                    diagnostics_report.record_failure(msg, self)
 
         except ECCMalfunctionException as e:
             LOGGER.exception(e)

--- a/hw_diag/tests/diagnostics/test_ecc_diagnostic.py
+++ b/hw_diag/tests/diagnostics/test_ecc_diagnostic.py
@@ -39,6 +39,30 @@ class TestECCDiagnostic(unittest.TestCase):
         })
 
     @patch(
+      "hw_diag.diagnostics.ecc_diagnostic.get_gateway_mfr_test_result",
+      return_value={
+        'result': 'pass',
+        'tests': {
+          'test1': {'result': 'pass'},
+          'key_config(2)': {'checks': {'lockable': {'found': 'false'}}, 'result': 'fail'},
+          'test3': {'result': 'pass'},
+        }
+      })
+    @patch(
+      "hw_diag.diagnostics.ecc_diagnostic.get_ecc_location",
+      return_value='ecc://i2c-1:88?slot=2')
+    def test_success_lockable_0x58(self, mock1, mock2):
+        diagnostic = EccDiagnostic()
+        diagnostics_report = DiagnosticsReport([diagnostic])
+        diagnostics_report.perform_diagnostics()
+
+        self.assertDictEqual(diagnostics_report, {
+            DIAGNOSTICS_PASSED_KEY: True,
+            DIAGNOSTICS_ERRORS_KEY: [],
+            'ECC': True
+        })
+
+    @patch(
         "hw_diag.diagnostics.ecc_diagnostic.get_gateway_mfr_test_result",
         side_effect=ECCMalfunctionException("ECC Malfunctioned"))
     def test_ecc_exception(self, mock):


### PR DESCRIPTION
**Issue**

ECCs at address 0x58 (found on some SyncroB.its) are expected to fail the `lockable` test and therefore require a workaround.

This PR modifies the ECC diagnostic result so that if (1) ECC is at 0x58 and (2) the _only_ failed test is the `lockable` one, the diagnostic result would still be successful.

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

