### PR TITLE
Don't fetch BlueZ objs unless service present

### DIFF
--- a/hw_diag/diagnostics/bt_diagnostic.py
+++ b/hw_diag/diagnostics/bt_diagnostic.py
@@ -50,6 +50,9 @@ class BtDiagnostic(Diagnostic):
     def get_bt_devices(self) -> list:
         bt_devices = []
         bus = dbus.SystemBus()
+        if self.DBUS_BLUEZ_SERVICE_NAME not in dbus.SystemBus().list_names():
+            LOGGER.info("Bluetooth support not present")
+            return []
         proxy_object = bus.get_object(self.DBUS_BLUEZ_SERVICE_NAME, "/")
         dbus_obj_mgr = dbus.Interface(proxy_object, self.DBUS_OBJECTMANAGER)
         dbus_objs = dbus_obj_mgr.GetManagedObjects()

--- a/hw_diag/tests/test_hardware.py
+++ b/hw_diag/tests/test_hardware.py
@@ -31,7 +31,7 @@ class TestHardware(unittest.TestCase):
 
     @patch('dbus.SystemBus')
     @patch('dbus.Interface')
-    def test_get_ble_devices_success(self, mocked_interface, _):
+    def test_get_ble_devices_success(self, mocked_interface, mocked_bus):
         # Prepare mocked BLE devices
         mocked_ble_devices = {
             '/org/bluez/hci0': {
@@ -57,6 +57,10 @@ class TestHardware(unittest.TestCase):
         mocked_interface = mocked_interface.return_value
         mocked_interface.GetManagedObjects.return_value = mocked_ble_devices
 
+        # Mock the names of services returned by the bus
+        mocked_bus = mocked_bus.return_value
+        mocked_bus.list_names.return_value = ['org.bluez']
+
         # Retrieve list of BLE devices
         ble_devices = get_ble_devices()
 
@@ -81,6 +85,20 @@ class TestHardware(unittest.TestCase):
         # Set mocked BLE devices in dbus
         mocked_interface = mocked_interface.return_value
         mocked_interface.GetManagedObjects.return_value = mocked_ble_devices
+
+        # Retrieve list of BLE devices
+        ble_devices = get_ble_devices()
+
+        # Assertion
+        self.assertIsInstance(ble_devices, list)
+        self.assertEqual(len(ble_devices), 0)
+
+    @patch('dbus.SystemBus')
+    @patch('dbus.Interface')
+    def test_get_ble_devices_no_service(self, _, mocked_bus):
+        # Mock the names of services returned by the bus
+        mocked_bus = mocked_bus.return_value
+        mocked_bus.list_names.return_value = ['something.Else']
 
         # Retrieve list of BLE devices
         ble_devices = get_ble_devices()

--- a/hw_diag/utilities/hardware.py
+++ b/hw_diag/utilities/hardware.py
@@ -85,6 +85,9 @@ def get_ble_devices():
     ble_devices = []
     try:
         bus = dbus.SystemBus()
+        if DBUS_BLUEZ_SERVICE_NAME not in dbus.SystemBus().list_names():
+            logging.info("Bluetooth support not present")
+            return []
         proxy_object = bus.get_object(DBUS_BLUEZ_SERVICE_NAME, "/")
         dbus_obj_mgr = dbus.Interface(proxy_object, DBUS_OBJECTMANAGER)
         dbus_objs = dbus_obj_mgr.GetManagedObjects()


### PR DESCRIPTION
**Issue**

In the absence of a Bluetooth adapter, diagnostics (local dashboard, initFile.txt) will load after an unwelcome timeout. This happens because we attempt to fetch the BlueZ objects from DBus while the corresponding service is not registered on DBus.

This PR simply checks for the presence of the BlueZ service on DBus prior to fetching adapters, thus avoiding unnecessary timeouts.

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

