### PR TITLE
fix: add N/A to freq as no longer required

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@
 # the repo. Unless a later match takes precedence,
 # @global-owner1 and @global-owner2 will be requested for
 # review when someone opens a pull request.
-*       @NebraLtd/device-team
+*       @NebraLtd/device-team @NebraLtd/developers
 
 # See example for more details: https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners#example-of-a-codeowners-file

--- a/hw_diag/templates/helium_info.html
+++ b/hw_diag/templates/helium_info.html
@@ -48,7 +48,7 @@
                 <tr>
                   {% if not diagnostics.FR %}
                     <td>Frequency</td>
-                    <td class="text-right">None</td>
+                    <td class="text-right">N/A (Not Required)</td>
                   {% elif "N/A" in diagnostics.FR %}
                     <td>Frequency</td>
                     <td class="text-right">{{ diagnostics.FR }}</td>


### PR DESCRIPTION
Show N/A (Not Required) for frequency on Nebra devices with missing frequency environment variable as this is no longer required and only used for manufacturing

**Issue**

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

