### PR TITLE
feat: show backup pending till such time the user takes a backup.

### DIFF
--- a/hw_diag/templates/device_info.html
+++ b/hw_diag/templates/device_info.html
@@ -3,6 +3,36 @@
  {% block title %}Device Information{% endblock %}
 
  {% block body %}
+    {% if backup_pending|length != 0 %}
+    <div class="modal show" id="backup-popup" tabindex="999" role="dialog">
+      <div class="modal-dialog" role="document">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">Warning</h5>
+          </div>
+          <div class="modal-body">
+            <p>Records indicate that you have added services that have not been backed up.<br>
+              In order to avoid data loss you should create a backup after such configuration changes.
+              You can do so by visiting <a href='/backup_restore'>Backup Page</a>
+            </p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" onclick="backup_button_clicked()" class="btn btn-primary">I understand</button>
+          </div>
+        </div>
+      </div>
+    </div>
+    <script>
+      var myModal = null;
+      document.addEventListener("DOMContentLoaded", function(event) {
+        myModal = new bootstrap.Modal(document.getElementById('backup-popup'));
+        myModal.show();
+      });
+      function backup_button_clicked() {
+        myModal.hide();
+      }
+    </script>
+    {% endif %}
      <div class="alert alert-primary alert-dismissible fade show" role="alert">
         <h2 class="alert-heading">Now supporting Multi-mining with MYST!</h2>
         <a href="https://www.nebra.com/blogs/news/unleashing-your-hotspot-dual-earnings-with-nebra-and-mystnodes" target="_blank"

--- a/hw_diag/tests/test_backup.py
+++ b/hw_diag/tests/test_backup.py
@@ -1,0 +1,152 @@
+import tempfile
+import hashlib
+import yaml
+import json
+import os
+
+import unittest
+from unittest.mock import patch
+
+from hw_diag.utilities.backup.myst import MystBackupRestore
+from hw_diag.utilities.backup.thingsix import ThingsIXBackupRestore
+from hw_diag.utilities.backup import update_backup_checkpoint, services_pending_backup
+from hw_diag.utilities.crypto import empty_hash
+from hw_diag.app import get_app
+
+
+class PerformBackupTestCase(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.app = get_app('test_app', lean_initializations=False)
+
+        # myst plugin back dir and plugin
+        self.temp_backup_dir = tempfile.TemporaryDirectory()
+        self.myst_backup_plugin = MystBackupRestore(self.temp_backup_dir.name)
+
+        # myst storage dir and keystore dir
+        self.temp_myst_dir = tempfile.TemporaryDirectory()
+        self.temp_myst_keystore_dirname = f'{self.temp_myst_dir.name}/keystore'
+        os.mkdir(self.temp_myst_keystore_dirname)
+
+        # thingsix plugin
+        self.thingsix_backup_plugin = ThingsIXBackupRestore(self.temp_backup_dir.name)
+
+        # thingsix storage dir and keystore dir
+        self.temp_thingsix_dir = tempfile.TemporaryDirectory()
+
+        # temp data
+        self.myst_json = {
+            "address": "1e775ed21d80b37368ea9334dc1da2a843sfsdfwe",
+            "crypto": {
+                "cipher": "aes-128-ctr",
+                "ciphertext": "885657ccdcc14ea3d1c507ded4bc61ea7ba0adf28448f48461089e054d1ea324",
+                "cipherparams": {
+                    "iv": "44eb243edbe6e3e46a1f788940d53bb2"
+                },
+                "kdf": "scrypt",
+                "kdfparams": {
+                    "dklen": 32,
+                    "n": 4096,
+                    "p": 6,
+                    "r": 8,
+                    "salt": "a2a246a5386ff33c312420c36403650930703b0fec0a7e2b771ea79335c9e214"
+                },
+                "mac": "eb96c96618d85fffcefc8c163d880971c6ddc71cbf5abedb4322f4f5630231242"
+            },
+            "id": "3bb7a107-6089-44d4-9f54-9176f50fsdfsdf",
+            "version": 3
+        }
+        self.myst_json_str = json.dumps(self.myst_json).encode()
+        self.myst_hash = hashlib.sha256(self.myst_json_str).hexdigest()
+
+        # thingsix id data
+        self.thingsix_yaml = [
+            {
+                "local_id": "0000ee6aeb9ad0bf",
+                "private_key": "46e22dfc15cf4a548269143da6cd17cfa7c6eb1c900ace4ffd08987f6aadd432"
+            }
+        ]
+        self.thingsix_str = yaml.dump(self.thingsix_yaml).encode()
+        self.thingsix_hash = hashlib.sha256(self.thingsix_str).hexdigest()
+
+    def tearDown(self):
+        self.temp_backup_dir.cleanup()
+
+    def test_myst_identity_hash_with_valid_json(self):
+        with patch('hw_diag.utilities.backup.myst.MYST_DIR', self.temp_myst_dir.name):
+            # write the mocked data to file
+            temp_file = tempfile.NamedTemporaryFile(dir=self.temp_myst_keystore_dirname,
+                                                    prefix='UTC', delete=False)
+            print(temp_file.name)
+            temp_file.write(self.myst_json_str)
+            temp_file.close()
+
+            # verify
+            expected_result = {'Mysterium': self.myst_hash}
+            actual_result = self.myst_backup_plugin.identity_hash()
+            self.assertEqual(expected_result, actual_result)
+
+    def test_myst_identity_hash_with_invalid_json(self):
+        with patch('hw_diag.utilities.backup.myst.MYST_DIR', self.temp_myst_dir.name):
+            # write the mocked data to file
+            temp_file = tempfile.NamedTemporaryFile(dir=self.temp_myst_keystore_dirname,
+                                                    prefix='UTC', delete=False)
+            print(temp_file.name)
+            temp_file.write(b'invalid_json')
+            temp_file.close()
+
+            # verify
+            expected_result = {'Mysterium': empty_hash()}
+            actual_result = self.myst_backup_plugin.identity_hash()
+            self.assertEqual(expected_result, actual_result)
+
+    def test_myst_identity_hash_with_no_files(self):
+        with patch('hw_diag.utilities.backup.myst.MYST_DIR', self.temp_myst_dir.name):
+            # verify
+            expected_result = {'Mysterium': empty_hash()}
+            actual_result = self.myst_backup_plugin.identity_hash()
+            self.assertEqual(expected_result, actual_result)
+
+    def test_thingsix_identity_hash_with_valid_yaml(self):
+        with patch('hw_diag.utilities.backup.thingsix.THIX_DIR', self.temp_thingsix_dir.name):
+            # write the mocked data to file
+            with open(f"{self.temp_thingsix_dir.name}/gateways.yaml", 'wb') as temp_file:
+                temp_file.write(self.thingsix_str)
+
+            expected_result = {'Thingsix': self.thingsix_hash}
+            actual_result = self.thingsix_backup_plugin.identity_hash()
+            self.assertEqual(expected_result, actual_result)
+
+    def test_thingsix_identity_hash_with_invalid_yaml(self):
+        with patch('hw_diag.utilities.backup.thingsix.THIX_DIR', self.temp_thingsix_dir.name):
+            # write the mocked data to file
+            with open(f"{self.temp_thingsix_dir.name}/gateways.yaml", 'wb') as temp_file:
+                temp_file.write(b"")
+
+            expected_result = {'Thingsix': empty_hash()}
+            actual_result = self.thingsix_backup_plugin.identity_hash()
+            self.assertEqual(expected_result, actual_result)
+
+    @patch('hw_diag.utilities.backup.set_value')
+    @patch('hw_diag.utilities.backup.identity_hashes')
+    def test_update_backup_checkpoint(self, mock_identity_hashes, mock_set_value):
+        with self.app.app_context():
+            mock_identity_hashes.return_value = {
+                'Thingsix': 'e1f710d70188be017a403f0c3816e3cffcf8e95f9e3e08e41d2fb6de48fe0ce2',
+                'Mysterium': 'e1f710d70188be017a403f0c3816e3cffcf8e95f9e3e08e41d2fb6de48fe0cz2'
+            }
+            update_backup_checkpoint()
+            self.assertEqual(mock_set_value.call_count, 2)
+
+    @patch('hw_diag.utilities.backup.get_value')
+    @patch('hw_diag.utilities.backup.identity_hashes')
+    def test_services_pending_backup(self, mock_identity_hashes, mock_get_value):
+        mock_identity_hashes.return_value = {'service': 'new_hash'}
+        mock_get_value.return_value = 'old_hash'
+        expected = ['service']
+        actual = services_pending_backup()
+        self.assertEqual(expected, actual)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hw_diag/tests/test_crypto.py
+++ b/hw_diag/tests/test_crypto.py
@@ -1,0 +1,47 @@
+import hashlib
+import unittest
+from unittest.mock import mock_open, patch
+from hw_diag.utilities.crypto import calculate_file_hash, empty_hash
+
+
+def mock_file_read(chunk_size):
+    return b'This is a sample chunk.'
+
+
+class CalculateFileHashTestCase(unittest.TestCase):
+    def test_calculate_file_hash_single_file(self):
+        file_path = 'file1.txt'
+        expected_hash = hashlib.sha256(b'This is a sample chunk.').hexdigest()
+
+        with patch('builtins.open', mock_open(read_data=b'This is a sample chunk.')):
+            result = calculate_file_hash([file_path])
+
+        self.assertEqual(result, expected_hash)
+
+    def test_calculate_file_hash_multiple_files(self):
+        file_paths = ['file1.txt', 'file2.txt', 'file3.txt']
+        expected_hash = hashlib.sha256(b'This is a sample chunk.' * 3).hexdigest()
+
+        with patch('builtins.open', mock_open(read_data=b'This is a sample chunk.')):
+            result = calculate_file_hash(file_paths)
+
+        self.assertEqual(result, expected_hash)
+
+    def test_calculate_file_hash_no_files(self):
+        file_paths = []
+        expected_hash = hashlib.sha256(b'').hexdigest()
+
+        result = calculate_file_hash(file_paths)
+
+        self.assertEqual(result, expected_hash)
+
+    def test_empty_hash(self):
+        expected_hash = hashlib.sha256(b'').hexdigest()
+
+        result = empty_hash()
+
+        self.assertEqual(result, expected_hash)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hw_diag/utilities/backup/base.py
+++ b/hw_diag/utilities/backup/base.py
@@ -7,6 +7,15 @@ class BaseBackupRestore(object):
     def __init__(self, tmpdir):
         self.tmpdir = '%s/%s' % (tmpdir, self.name)
 
+    def identity_hash(self) -> dict[str, str]:
+        '''
+        returns a dict of where key is a friendly name of service
+        and value is sha256 hash of identity data.
+        We use it to decide if a backup is needed or not.
+        if there is no identity data, return empty dict
+        '''
+        return {}
+
     def backup(self):
         pass
 

--- a/hw_diag/utilities/backup/myst.py
+++ b/hw_diag/utilities/backup/myst.py
@@ -1,8 +1,14 @@
 import os
 import shutil
+import glob
+import json
 
 from hw_diag.utilities.backup.base import BaseBackupRestore
+from hw_diag.utilities.crypto import calculate_file_hash
 
+from hm_pyhelper.logger import get_logger
+
+logging = get_logger(__name__)
 
 MYST_DIR = '/var/myst'
 
@@ -15,3 +21,18 @@ class MystBackupRestore(BaseBackupRestore):
 
     def restore(self):
         os.system('cp -r %s/* %s/.' % (self.tmpdir, MYST_DIR))  # nosec
+        
+    def identity_hash(self) -> dict[str, str]:
+        # find the file matching UTC* in myst key store
+        file_paths = glob.glob(f'{MYST_DIR}/keystore/UTC*')
+        logging.debug(f"myst keystore files: {file_paths}")
+        # check if the file is valid json document
+        for file in file_paths:
+            try:
+                with open(file, 'r') as f:
+                    json.load(f)
+            except json.JSONDecodeError as e:
+                logging.error(f"corrupt file: {file} : {e}")
+                file_paths.remove(file)
+
+        return {'Mysterium': calculate_file_hash(file_paths)}

--- a/hw_diag/utilities/backup/thingsix.py
+++ b/hw_diag/utilities/backup/thingsix.py
@@ -1,8 +1,13 @@
 import os
 import shutil
+import yaml
 
 from hw_diag.utilities.backup.base import BaseBackupRestore
+from hw_diag.utilities.crypto import calculate_file_hash
 
+from hm_pyhelper.logger import get_logger
+
+logging = get_logger(__name__)
 
 THIX_DIR = '/var/thix'
 
@@ -15,3 +20,17 @@ class ThingsIXBackupRestore(BaseBackupRestore):
 
     def restore(self):
         os.system('cp -r %s/* %s/.' % (self.tmpdir, THIX_DIR))  # nosec
+        
+    def identity_hash(self) -> dict[str, str]:
+        file_paths = [f"{THIX_DIR}/gateways.yaml"]
+
+        # check if the file is valid json document
+        for file in file_paths:
+            try:
+                with open(file, 'r') as f:
+                    yaml.safe_load(f)
+            except yaml.YAMLError as e:
+                logging.error(f"corrupt file: {file} : {e}")
+                file_paths.remove(file)
+
+        return {'Thingsix': calculate_file_hash(file_paths)}

--- a/hw_diag/utilities/crypto.py
+++ b/hw_diag/utilities/crypto.py
@@ -1,0 +1,25 @@
+import hashlib
+
+from hm_pyhelper.logger import get_logger
+
+logging = get_logger(__name__)
+
+
+def calculate_file_hash(files: list[str],
+                        hash_algorithm='sha256',
+                        block_size=4096):
+    '''returns combined hash of a list of files'''
+    hash_object = hashlib.new(hash_algorithm)
+
+    for file_path in files:
+        with open(file_path, 'rb') as file:
+            # Read the file in chunks to handle large files efficiently
+            for chunk in iter(lambda: file.read(block_size), b''):
+                hash_object.update(chunk)
+    logging.debug(f"hash for {files} is : {hash_object.hexdigest()}")
+    return hash_object.hexdigest()
+
+
+def empty_hash(hash_algorithm='sha256', block_size=4096):
+    '''return hash of an empty string'''
+    return calculate_file_hash([], hash_algorithm, block_size)

--- a/hw_diag/utilities/db.py
+++ b/hw_diag/utilities/db.py
@@ -4,13 +4,15 @@ from sqlalchemy.exc import NoResultFound
 from hw_diag.database.models.auth import AuthKeyValue
 
 
-def get_value(key):
+def get_value(key, default=None):
     try:
         row = g.db.query(AuthKeyValue). \
             filter(AuthKeyValue.key == key). \
             one()
         return row.value
     except NoResultFound:
+        if default:
+            return default
         raise Exception("No value found for key %s" % key)
 
 

--- a/hw_diag/utilities/security.py
+++ b/hw_diag/utilities/security.py
@@ -4,6 +4,10 @@ import shutil
 
 import gnupg
 
+from hm_pyhelper.logger import get_logger
+
+logging = get_logger(__name__)
+
 
 class GnuPG(object):
     def __init__(self, gnupghome: str = None):

--- a/hw_diag/views/backup_restore.py
+++ b/hw_diag/views/backup_restore.py
@@ -10,6 +10,7 @@ from hm_pyhelper.logger import get_logger
 from hw_diag.utilities.auth import authenticate
 from hw_diag.utilities.backup import perform_backup
 from hw_diag.utilities.backup import perform_restore
+from hw_diag.utilities.backup import update_backup_checkpoint
 from hw_diag.utilities.balena_supervisor import BalenaSupervisor
 
 
@@ -29,6 +30,7 @@ def get_backup_page():
 @authenticate
 def do_backup():
     backup_file = perform_backup()
+    update_backup_checkpoint()
     return send_file(backup_file, as_attachment=True)
 
 
@@ -42,6 +44,7 @@ def do_restore():
         return "Bad Request: Invalid backup file", 400
     try:
         perform_restore()
+        update_backup_checkpoint()
         supervisor = BalenaSupervisor.new_from_env()
         supervisor.reboot()
 

--- a/hw_diag/views/diagnostics.py
+++ b/hw_diag/views/diagnostics.py
@@ -44,6 +44,7 @@ from hw_diag.utilities.balena_supervisor import BalenaSupervisor
 from hw_diag.utilities.network import get_device_hostname
 from hw_diag.utilities.network import get_wan_ip_address
 from hw_diag.utilities.dashboard_registration import claim_miner_deeplink
+from hw_diag.utilities.backup import services_pending_backup
 
 
 logging.basicConfig(level=os.environ.get("LOGLEVEL", "DEBUG"))
@@ -75,6 +76,7 @@ def get_diagnostics():
     wan_ip = get_wan_ip_address()
     device_metrics = get_device_metrics()
     claim_deeplink = claim_miner_deeplink()
+    backup_pending_services = services_pending_backup()
 
     response = render_template(
         template_filename,
@@ -85,7 +87,8 @@ def get_diagnostics():
         device_info=device_info,
         wan_ip_address=wan_ip,
         device_metrics=device_metrics,
-        claim_deeplink=claim_deeplink
+        claim_deeplink=claim_deeplink,
+        backup_pending=backup_pending_services
     )
 
     return response


### PR DESCRIPTION
* a diaglog appears on the device info page
* the dialog disappears after click of the button but will come back every reload.
* only way to permanently disable the diaglog is to take a backup.

**[Issue](https://nebraltd.atlassian.net/browse/NEBD-238)**

- Link:
- Summary:

**How**
* a diaglog appears on the device info page
* the dialog disappears after click of the button but will come back every reload.
* only way to permanently disable the diaglog is to take a backup.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

![backup](https://github.com/NebraLtd/hm-diag/assets/6928727/f0070cba-e883-4ad4-9fa4-f72e8bb89053)
