### PR TITLE
feat: add premium indicator to firmware version and change claim link

### DIFF
--- a/hw_diag/templates/device_info.html
+++ b/hw_diag/templates/device_info.html
@@ -54,8 +54,13 @@
        <div class="card mb-0 h-100 table-responsive">
          <table class="table dt-responsive nowrap m-2 w-auto">
            <tr>
+             {% if diagnostics and diagnostics.BA and diagnostics.BA.endswith('-c') %}
+             <td><span class="uil uil-refresh icon"></span> Firmware Version</td>
+             <td class="text-right"><i class="fa fa-star" aria-hidden="true"></i> Premium - {{ diagnostics.FW }} ({{ diagnostics.firmware_short_hash }})</td>
+             {% else %}
              <td><span class="uil uil-refresh icon"></span> Firmware Version</td>
              <td class="text-right">{{ diagnostics.FW }} ({{ diagnostics.firmware_short_hash }})</td>
+             {% endif %}
            </tr>
            <tr>
              <td><span class="uil uil-focus icon"></span> Variant</td>
@@ -232,7 +237,11 @@
      <p>Last Updated: Never</p>
      {% endif %}
      <p>To get support please visit <a href="https://nebra.io/support-diag-footer">the Nebra knowledgebase</a></p>
+     {% if diagnostics and diagnostics.BA and diagnostics.BA.endswith('-c') %}
+     <p><a href="https://dashboard.nebra.com/devices/{{ diagnostics.serial_number }}/">View your device on dashboard</a></p>
+     {% else %}
      <p><a href={{ claim_deeplink }}>Claim your device on dashboard</a></p>
+     {% endif %}
      <p><a href="/json">Download Diagnostics Info for Support</a></p>
    </div>
  </div>


### PR DESCRIPTION
- add premium indicator to firmware version
- if on a commercial fleet, this changes the "claim on dashboard" link to "view device on dashboard" as it should already be connected to the dashboard in that case

Closes: #380 
Relates-to: #581

**Issue**

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

<img width="1424" alt="Screenshot 2023-06-07 at 17 43 09" src="https://github.com/NebraLtd/hm-diag/assets/3359418/cbab2faa-d6ed-4ad7-a441-7fe0e1d5d634">

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names

